### PR TITLE
Update link for getting started git repo

### DIFF
--- a/src/pages/get_started/get_started.md
+++ b/src/pages/get_started/get_started.md
@@ -36,7 +36,7 @@ Then, in PlatformIO:
 Clone the *getting started* repository on your computer: 
 
 ```bash
-git clone https://github.com/Luos-io/getting_started.git
+git clone https://github.com/Luos-io/Get_started.git
 ```
 
 If you are not familiar with Git, you can consult <a href="https://git-scm.com/doc" target="_blank">their documentation &#8599;</a>.


### PR DESCRIPTION
Getting started repository has been renamed. So, link from documentation is uptaded.