### PR TITLE
Ignore React 18 dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,5 +20,11 @@ updates:
       - 'update'
       - 'dependencies'
     ignore:
+      # https://github.com/facebook/docusaurus/pull/7102#pullrequestreview-935447321
+      - dependency-name: 'react'
+        versions: ['18.x']
       - dependency-name: '@types/node'
         versions: ['17.x']
+      # https://github.com/facebook/docusaurus/pull/7102#pullrequestreview-935447321
+      - dependency-name: '@types/react'
+        versions: ['18.x']


### PR DESCRIPTION
As stated here : https://github.com/facebook/docusaurus/pull/7102#pullrequestreview-935447321, we'll not follow React 18 updates as long Docusaurus and their own dependencies are not update