### PR TITLE
Fix/seo problems

### DIFF
--- a/docs/api/api-json.mdx
+++ b/docs/api/api-json.mdx
@@ -13,7 +13,7 @@ import Image from '@site/src/components/Images.js';
   </a>
 </h1>
 
-The <a href="https://en.wikipedia.org/wiki/JSON" target="blank_">JSON formatted data</a> is common and widely used by many programming languages. Gate services allow you to convert Luos engine information into JSON objects, enabling conventional programming languages to interact with your device easily.
+The <a href="https://en.wikipedia.org/wiki/JSON" target="blank_" rel="external nofollow">JSON formatted data</a> is common and widely used by many programming languages. Gate services allow you to convert Luos engine information into JSON objects, enabling conventional programming languages to interact with your device easily.
 
 To do that, you must add a specific app service called a [gate](../tools/gate) on your device.
 

--- a/docs/hardware-consideration/electronics.mdx
+++ b/docs/hardware-consideration/electronics.mdx
@@ -29,7 +29,7 @@ A Luos-friendly electronic board must contain _at least_ the following elements:
   />
 </div>
 
-Robus' One-wire official connector is <a href="https://octopart.com/df11-4dp-2ds%2852%29-hirose-261749" target="_blank">_DF11-4DP-2DS<IconExternalLink width="10"></IconExternalLink>_</a>.
+Robus' One-wire official connector is <a href="https://octopart.com/df11-4dp-2ds%2852%29-hirose-261749" target="_blank" rel="external nofollow">_DF11-4DP-2DS<IconExternalLink width="10"></IconExternalLink>_</a>.
 
 ## RS485 reference design
 
@@ -40,6 +40,6 @@ Robus' One-wire official connector is <a href="https://octopart.com/df11-4dp-2ds
   />
 </div>
 
-Robus' RS485 official connector is <a href="https://octopart.com/df11-8dp-2ds%2824%29-hirose-39521447" target="_blank">_DF11-8DP-2DS<IconExternalLink width="10"></IconExternalLink>_</a>.
+Robus' RS485 official connector is <a href="https://octopart.com/df11-8dp-2ds%2824%29-hirose-39521447" target="_blank" rel="external nofollow">_DF11-8DP-2DS<IconExternalLink width="10"></IconExternalLink>_</a>.
 
-See the default pinout configuration in the <a href="https://github.com/Luos-io/luos_engine/tree/main/Network/Robus/HAL" target="_blank">_luos_hal_config.h<IconExternalLink width="10"></IconExternalLink>_</a> file, situated in the folder associated to the chosen MCU family.
+See the default pinout configuration in the <a href="https://github.com/Luos-io/luos_engine/tree/main/network/robus/HAL" target="_blank" rel="external nofollow">_luos_hal_config.h<IconExternalLink width="10"></IconExternalLink>_</a> file, situated in the folder associated to the chosen MCU family.

--- a/docs/hardware-consideration/index.mdx
+++ b/docs/hardware-consideration/index.mdx
@@ -8,8 +8,8 @@ import IconExternalLink from "@theme/IconExternalLink";
 
 Luos engine needs to acces your hardware to properly work.
 
-When creating a Luos network, if you have a product with several nodes, it is mandatory to configure your MCU to create the network's physical layer. In <a href="https://github.com/Luos-io/luos_engine/tree/main/Examples/" target="_blank">Luos's examples on GitHub<IconExternalLink width="10"></IconExternalLink></a>, we use the Robus network interface with RS485 or one-wire communication (for this physical layer [see Electronic design](./electronics) page), but other networks can be used as well.
+When creating a Luos network, if you have a product with several nodes, it is mandatory to configure your MCU to create the network's physical layer. In <a href="https://github.com/Luos-io/luos_engine/tree/main/examples" target="_blank" rel="external nofollow">Luos's examples on GitHub<IconExternalLink width="10"></IconExternalLink></a>, we use the Robus network interface with RS485 or one-wire communication (for this physical layer [see Electronic design](./electronics) page), but other networks can be used as well.
 
-Board examples and driver sources are available <a href="https://github.com/Luos-io/luos_engine/tree/main/Examples/tree/master/Projects" target="_blank">on GitHub<IconExternalLink width="10"></IconExternalLink></a>. We encourage you to use them as a reference, the way you want.
+Board examples and driver sources are available <a href="https://github.com/Luos-io/luos_engine/tree/main/examples/projects" target="_blank" rel="external nofollow">on GitHub<IconExternalLink width="10"></IconExternalLink></a>. We encourage you to use them as a reference, the way you want.
 
-You can find the schematics of a Luos-ready board called L0 <a href="https://github.com/Luos-io/luos_engine/tree/main/Examples/tree/master/Hardware/l0" target="_blank">on Github<IconExternalLink width="10"></IconExternalLink></a> for a quick hardware example.
+You can find the schematics of a Luos-ready board called L0 <a href="https://github.com/Luos-io/luos_engine/tree/main/examples/hardware/l0" target="_blank" rel="external nofollow">on Github<IconExternalLink width="10"></IconExternalLink></a> for a quick hardware example.

--- a/docs/hardware-consideration/mcu.mdx
+++ b/docs/hardware-consideration/mcu.mdx
@@ -14,7 +14,7 @@ Luos engine can manage any type of microcontrollers as long as they have a HAL. 
 - by mail <a href="mailto:hello@luos.io">hello&#x40;luos.io</a>
 - on <a href="https://github.com/Luos-io/luos_engine/issues/new?assignees=nicolas-rabault&labels=porting&template=porting-request.md&title=%5BMCU+PORTING%5D+" target="_blank">GitHub</a>
 
-Check the list of MCU families Luos engine cover:<a href="https://github.com/Luos-io/luos_engine/tree/main/Engine/HAL" target="_blank">Hardware Abstraction Layers for MCU families</a>,
+Check the list of MCU families Luos engine cover:<a href="https://github.com/Luos-io/luos_engine/tree/main/engine/HAL" target="_blank">Hardware Abstraction Layers for MCU families</a>,
 
 > Depending on what network you have, you may also configure the specific HAL of your network. By default, Luos engine uses the Robus network layer with <a href="https://github.com/Luos-io/luos_engine/tree/main/Network/Robus/HAL" target="_blank">Robus HAL</a>.
 

--- a/docs/hardware-consideration/test-your-configuration.mdx
+++ b/docs/hardware-consideration/test-your-configuration.mdx
@@ -1,7 +1,7 @@
 # Test your Robus configuration
 
 To adapt Luos engine to your board specificities, you need to configure it. This subject is covered in the [Luos engine configuration](./mcu).
-To validate your Robus network's hardware configuration, you can use a Robus tool called _selftest_ available in the <a href="https://github.com/Luos-io/luos_engine/tree/main/Network/Robus/SelfTest" target="_blank">Luos engine's 'library<IconExternalLink width="10"></IconExternalLink></a>.
+To validate your Robus network's hardware configuration, you can use a Robus tool called _selftest_ available in the <a href="https://github.com/Luos-io/luos_engine/tree/main/network/robus/selftest" target="_blank" rel="external nofollow">Luos engine's 'library<IconExternalLink width="10"></IconExternalLink></a>.
 
 ## Hardware test conditions
 

--- a/docs/luos-technology/basics/concept.mdx
+++ b/docs/luos-technology/basics/concept.mdx
@@ -18,7 +18,7 @@ Technically, this engine is an embedded lightwheight and realtime C code library
 As Luos engine is not an operating system, you can use it with or without any operating system.
 :::
 
-Luos engine is open-source under _Apache 2.0_ license and available [on GitHub](https://github.com/Luos-io/luos_engine/tree/main).
+Luos engine is open-source under _Apache 2.0_ license and available <a href="https://github.com/Luos-io/luos_engine/tree/main" target ="_blank" rel="external nofollow">on GitHub</a>.
 
 ## What is a Node?
 
@@ -47,7 +47,7 @@ Services, much like their server-world counterparts, can be placed anywhere in y
 
 **Each service is hosted in a single node**, but you can have the same service duplicated multiple times in your product.
 
-For instance, the Dynamixel example (available in the [Luos engine example folder](https://github.com/Luos-io/luos_engine/tree/main/Examples)) can dynamically create servomotors services depending on the number of Dynamixel motors linked to it. Any Dynamixel service is visible as an independent servomotor similar to any other servomotor technology, such as the stepper service example or the controller motor service example. Then, you can use any of your Dynamixels from any other services or even from any computer, cloud program, or ecosystem such as ROS.
+For instance, the Dynamixel example (available in the <a href="https://github.com/Luos-io/luos_engine/tree/main/Examples" target ="_blank" rel="external nofollow">Luos engine example folder</a>) can dynamically create servomotors services depending on the number of Dynamixel motors linked to it. Any Dynamixel service is visible as an independent servomotor similar to any other servomotor technology, such as the stepper service example or the controller motor service example. Then, you can use any of your Dynamixels from any other services or even from any computer, cloud program, or ecosystem such as ROS.
 
 There are two categories of services, [drivers](../services/service-api#drivers-guidelines) or [applications](../services/service-api#apps-guidelines).
 

--- a/docs/luos-technology/basics/index.mdx
+++ b/docs/luos-technology/basics/index.mdx
@@ -19,7 +19,7 @@ Luos is here to back you up and keep your projects clean and smooth to develop, 
 
 ## Introduction to Luos
 
-**Luos is a simple and lightweight containerization platform dedicated to embedded systems enabling a <a href="https://en.wikipedia.org/wiki/Microservices" target="_blank">microservices<IconExternalLink width="10"></IconExternalLink></a> architecture for electronics.** It is a powerful modularity tool to simplify and link any hardware component or application code together as a <a href="https://en.wikipedia.org/wiki/Single_system_image" target="_blank">single system image<IconExternalLink width="10"></IconExternalLink></a>.
+**Luos is a simple and lightweight containerization platform dedicated to embedded systems enabling a <a href="https://en.wikipedia.org/wiki/Microservices" target="_blank" rel="external nofollow">microservices<IconExternalLink width="10"></IconExternalLink></a> architecture for electronics.** It is a powerful modularity tool to simplify and link any hardware component or application code together as a <a href="https://en.wikipedia.org/wiki/Single_system_image" target="_blank" rel="external nofollow">single system image<IconExternalLink width="10"></IconExternalLink></a>.
 
 This guide contains all the basic notions you will need to use, create and understand Luos technology.
 

--- a/docs/luos-technology/index.mdx
+++ b/docs/luos-technology/index.mdx
@@ -13,9 +13,7 @@ Luos engine is an open-source lightweight library that can be used on any MCU, l
 
 Most of the embedded developments are made from scratch. By using Luos engine, you will be able to capitalize on the development you, your company, or the Luos community already did. The re-usability of features encapsulated in Luos engine services will fasten the time your products reach the market and reassure the robustness and the universality of your applications.
 
-You can visit the Luos community on <a href="https://www.reddit.com/r/Luos/" target ="_blank">Reddit</a> or <a href="http://bit.ly/JoinLuosDiscord" target ="_blank">Discord</a>.
-
-Need dedicated help for your project? <a href="https://www.luos.io/support" target ="_blank">Check out Luos' support packages</a>.
+Need dedicated help for your project? You can join the Luos community on <a href="https://discord.gg/luos" target ="_blank" rel="external nofollow">Discord</a> or <a href="https://www.reddit.com/r/Luos/" target ="_blank" rel="external nofollow">Reddit</a>.
 
 ## Good practices with Luos
 

--- a/docs/luos-technology/message/command.mdx
+++ b/docs/luos-technology/message/command.mdx
@@ -94,6 +94,6 @@ User's commands start at `LUOS_LAST_RESERVED_CMD`.
 | PARAMETERS | depends on the service. It can be: servo_parameters_t, imu_report_t, motor_mode_t |
 | ERROR_CMD  |                                                                                   |
 
-You can find the complete list of commands <a href="https://github.com/Luos-io/luos_engine/blob/main/Engine/Core/inc/luos_list.h" target = "_blank">here<IconExternalLink width="10"></IconExternalLink></a>.
+You can find the complete list of commands <a href="https://github.com/Luos-io/luos_engine/blob/main/engine/core/inc/luos_list.h" target= "_blank" rel="external nofollow">here<IconExternalLink width="10"></IconExternalLink></a>.
 
 If you want to create new commands for your custom services, you can create and add your own starting at `LUOS_LAST_STD_CMD`. [See how](/tutorials).

--- a/docs/luos-technology/node/luos.mdx
+++ b/docs/luos-technology/node/luos.mdx
@@ -18,7 +18,7 @@ Luos engine works as a code library running on nodes. It can use several network
 To match the Luos engine's library with your hardware, it offers an _Hardware Abstraction Layer_ for various devices in the <Tooltip def={customFields.luoshal_def}>Luos engine's HAL folder</Tooltip>.
 There is also specific _Hardware Abstraction Layers_ for each network layer.
 
-- <a href="https://github.com/Luos-io/luos_engine" target="_blank">
+- <a href="https://github.com/Luos-io/luos_engine" target="_blank" rel="external nofollow">
     Luos engine
     <IconExternalLink width="10"></IconExternalLink>
   </a>
@@ -95,11 +95,11 @@ You can use it to set all your custom configurations:
 |     MAX_MSG_NB     | 2\*MAX_SERVICE_NUMBER |                               Max number of messages that can be referenced by Luos.                               |
 |      NBR_PORT      |           2           | Number of PTP (port) on the node ( max 8). See [electronic design](../../hardware-consideration/electronics) page. |
 
-You will find the default configuration for Luos engine in the file <a href="https://github.com/Luos-io/luos_engine/blob/main/Network/Robus/inc/config.h" target="_blank">_config.h<IconExternalLink width="10"></IconExternalLink>_</a>.
+You will find the default configuration for Luos engine in the file <a href="https://github.com/Luos-io/luos_engine/blob/main/network/robus/inc/config.h" target="_blank" rel="external nofollow">_config.h<IconExternalLink width="10"></IconExternalLink>_</a>.
 
 Check the _Luos_hal_config.h_ and your _Network_hal_config.h_ of your MCU family to see parameters that can be changed to fit your design.
 
-> **Note:** [Every example](https://github.com/Luos-io/luos_engine/tree/main/Examples) provided by Luos has a _node_config.h_ file that can be used as a base to fit your project's needs.
+> **Note:** [Every example](https://github.com/Luos-io/luos_engine/tree/main/examples) provided by Luos has a _node_config.h_ file that can be used as a base to fit your project's needs.
 
 ## Luos Statistics
 

--- a/docs/luos-technology/services/profile.mdx
+++ b/docs/luos-technology/services/profile.mdx
@@ -15,7 +15,7 @@ The profile handles messaging to share your variables with other services. Moreo
 :::
 
 Profiles are convenient for making your code clean and straightforward, complying with your development into a standard API, or sharing your service's type with the community.
-Luos engine provides some common profile models that you can use; feel free to contribute and to add your own to the standard profile bank with a pull request on <a href="https://github.com/Luos-io" target="_blank">Luos engine GitHub page &#8599;</a>.
+Luos engine provides some common profile models that you can use; feel free to contribute and to add your own to the standard profile bank with a pull request on <a href="https://github.com/Luos-io" target="_blank" rel="external nofollow">Luos engine GitHub page &#8599;</a>.
 
 ## How to use a profile in your service
 
@@ -66,4 +66,4 @@ void Button_Loop(void) {
 }
 ```
 
-You can notice that you did not send any Luos message to share the button's state: if an application wants to access this information, the state profile will share it for you. You only have to update the button's state value in your code. Supported profiles are available in this [repository](https://github.com/Luos-io/luos_engine/tree/main/Engine/Profiles).
+You can notice that you did not send any Luos message to share the button's state: if an application wants to access this information, the state profile will share it for you. You only have to update the button's state value in your code. Supported profiles are available in this <a href="https://github.com/Luos-io/luos_engine/tree/main/engine/profiles" target ="_blank" rel="external nofollow">repository</a>.

--- a/faq/001.detection-reconfig.mdx
+++ b/faq/001.detection-reconfig.mdx
@@ -16,7 +16,7 @@ When a detection occurs, Luos engine removes all auto-update automation, and doi
 
 If you already managed the re-detection on your app, the problem should come from the gate's configuration.
 By default a gate initiates an auto-update to all the services available on the network, improving its performance. But if you plan to have an application also using this feature on your network, you don't want the gate to make the auto-update anymore. You can avoid it by configuring your gate in `GATE_POLLING` mode.
-To do that, add `#define GATE_POLLING` in the file _node_config.h_. The entire list of gate's configuration is available in the [_gate_config.h_](https://github.com/Luos-io/Luos/blob/main/Tool_services/Gate/gate_config.h) file.
+To do that, add `#define GATE_POLLING` in the file _node_config.h_. The entire list of gate's configuration is available in the <a href="https://github.com/Luos-io/luos_engine/blob/main/tool_services/gate/gate_config.h" target="_blank" rel="external nofollow">_gate_config.h_</a> file.
 
 ### Resolution
 

--- a/faq/003.application-does-not-compile.mdx
+++ b/faq/003.application-does-not-compile.mdx
@@ -101,4 +101,4 @@ Below is an example of the file _node_config.h_ in your project:
 
 > **Associated page(s):**
 >
-> - [Examples](https://github.com/Luos-io/Luos/tree/main/Examples/Projects/NUCLEO-F401RE/Button)
+> - <a href="https://github.com/Luos-io/luos_engine/tree/main/examples/projects/NUCLEO-F401RE/button" target="_blank" rel="external nofollow">Examples</a>

--- a/faq/999.add-issue.mdx
+++ b/faq/999.add-issue.mdx
@@ -8,7 +8,6 @@ import IconExternalLink from "@theme/IconExternalLink";
 
 If you encounter an issue that should appear in the FAQ, you can describe it as precisely as possible by: 
 
- - <a href="mailto:support@luos.io?subject=Issue report">contacting us by email</a>.
- - Adding an issue on <a href="https://github.com/Luos-io/Luos-engine/issues/new/choose" target="_blank">Luos GitHub page<IconExternalLink width="10"></IconExternalLink></a>.
- - Asking your question in the <a href="https://www.reddit.com/r/Luos/" target="_blank">Luos Reddit community<IconExternalLink width="10"></IconExternalLink></a>.
- - Chatting with us in the <a href="http://bit.ly/JoinLuosDiscord" target="_blank">Luos Discord community<IconExternalLink width="10"></IconExternalLink></a>.
+ - Adding an issue on <a href="https://github.com/luos-io/luos_engine/issues/new/choose" target="_blank" rel="external nofollow">Luos GitHub page<IconExternalLink width="10"></IconExternalLink></a>.
+ - Chatting with us in the <a href="https://discord.gg/luos" target="_blank" rel="external nofollow">Luos Discord community<IconExternalLink width="10"></IconExternalLink></a>.
+ - Asking your question in the <a href="https://www.reddit.com/r/Luos/" target="_blank" rel="external nofollow">Luos Reddit community<IconExternalLink width="10"></IconExternalLink></a>.

--- a/tutorials/bike-alarm/basic-alarm.mdx
+++ b/tutorials/bike-alarm/basic-alarm.mdx
@@ -9,7 +9,7 @@ import Image from '@site/src/components/Images.js';
 The purpose of the bike alarm is to create an alarm that constantly measures a bike's movements while activated, and raise an alarm if the bike is moving.
 
 To make it work, we will use an IMU board to measure the bike's motions and, for now, an RGB LED board to display an alarm using a red blinky LED.
-For this tutorial, we are going to use [L0 board examples available in Luos examples](https://github.com/Luos-io/Luos/tree/main/Examples/Projects/l0).
+For this tutorial, we are going to use <a href="https://github.com/Luos-io/luos_engine/tree/main/examples/projects/l0" target="_blank" rel="external nofollow">L0 board examples available in Luos examples</a>.
 We are going to use IMU and LED drivers examples without any modifications and just add an embedded app to control them.
 This embedded app service will control the behavior of the alarm. This app can work on any node. 
 
@@ -58,7 +58,7 @@ void AlarmController_Loop(void);
 ```
 
 :::info
-For more details about Luos code organization, please read the [Luos project organization page](https://docs.luos.io/docs/next/luos-technology/basics/orga).
+For more details about Luos code organization, please read the [Luos project organization page](/docs/luos-technology/basics/orga).
 :::
 
 Now we have to fill both functions in the C file.
@@ -81,7 +81,7 @@ void AlarmController_Init(void)
 As you can see, our app default alias will be `"alarm_control"`, and we created a custom service type.
 
 :::info
-For more information about service creation, read the [Create Luos service page](https://docs.luos.io/docs/next/luos-technology/services/service-api).
+For more information about service creation, read the [Create Luos service page](/docs/luos-technology/services/service-api).
 :::
 
 To declare to others this custom service type, we need to add an enum in the C file:
@@ -119,7 +119,7 @@ void AlarmController_MsgHandler(service_t *service, msg_t *msg)
 Now we have to be able to get data from the IMU. To do that, our app will need a routing table. Routing tables are auto-generated and shared to all services in the network during detection.
 
 :::info
-For more information, read the [routing table page](https://docs.luos.io/docs/next/luos-technology/services/routing-table).
+For more information, read the [routing table page](/docs/luos-technology/services/routing-table).
 :::
 
 Because this app is stand-alone, it has to run a detection to create the routing table and configure the IMU to send gyro data each 10ms.

--- a/tutorials/bike-alarm/evolve-alarm.mdx
+++ b/tutorials/bike-alarm/evolve-alarm.mdx
@@ -52,14 +52,14 @@ The simplest way to rename a service is to use a gate and Pyluos.
 ## Add the truck horn on start_controller app
 
 In this app, we add a small "BIP" when locking or unlocking the bike. In order to add it, we have to add more code than in the previous app to manage time properly.
-You consult [the final code here](https://github.com/Luos-io/Luos/tree/main/Examples/Apps/Start_controller).
+You consult <a href="https://github.com/Luos-io/luos_engine/tree/main/examples/apps/start_controller" target="_blank" rel="external nofollow">the final code here</a>.
 
 We took advantage of this code modification to add some fancy animation on the LED, allowing it to be used as bicycle headlight.
 
 ## Improvement clue
 
 To make it usable in real life, we should probably select something less noisy than a truck horn which can be really painful for the ears.
-We also should add a real locking system which would be able to lock the bike wheel using a motor and a mechanism, like this one made by our friends from [Pony](https://getapony.com/):
+We also should add a real locking system which would be able to lock the bike wheel using a motor and a mechanism, like this one made by our friends from <a href="https://getapony.com/" target="_blank" rel="external nofollow">Pony</a>:
 
 <div align="center">
   <Image

--- a/tutorials/freertos/freertos.mdx
+++ b/tutorials/freertos/freertos.mdx
@@ -18,8 +18,8 @@ In this tutorial, we will see how to use Luos with an RTOS and discover the bene
 
 ## 1. Set up a PlatformIO project
 
-In this tutorial, we will use the examples available in [the Luos engine's repository](https://github.com/Luos-io/luos_engine/tree/main).
-You can [download](https://github.com/Luos-io/luos_engine/archive/refs/heads/main.zip) and unzip it or clone it using: 
+In this tutorial, we will use the examples available in <a href="https://github.com/Luos-io/luos_engine/tree/main" target="_blank" rel="external nofollow">the Luos engine's repository</a>.
+You can <a href="https://github.com/Luos-io/luos_engine/archive/refs/heads/main.zip" target="_blank" rel="external nofollow">download</a> and unzip it or clone it using: 
 
 ```
 Git clone https://github.com/Luos-io/luos_engine.git
@@ -38,7 +38,7 @@ Open Visual Studio Code and open a **Led** project corresponding to your master 
 If you are not comfortable with the opening and compiling of a Luos engine project, please follow [the Luos Get started tutorial](../get-started) first.
 :::
 
-Now we need to import FreeRTOS source files in our project. To do that we will use the PlatformIO registry and add a [dependency to FreeRTOS])(https://registry.platformio.org/libraries/bojit/PlatformIO-FreeRTOS). Then at compilation time PlatformIO will download it and include it on our project.
+Now we need to import FreeRTOS source files in our project. To do that we will use the PlatformIO registry and add a <a href="https://registry.platformio.org/libraries/bojit/PlatformIO-FreeRTOS" target="_blank" rel="external nofollow">dependency to FreeRTOS</a>. Then at compilation time PlatformIO will download it and include it on our project.
 
 To do that open the _platformio.ini_ file of your project and add a FreeRTOS dependency: 
 
@@ -53,13 +53,13 @@ To properly work, this lib needs to know which MCU family you are working on (li
 For example, for STM32F0 you have to add the compilation flag `-DSTM32F0`.
 
 :::info
-More details about it on [the PlatformIO library's readme](https://registry.platformio.org/libraries/bojit/PlatformIO-FreeRTOS).
+More details about it on <a href="https://registry.platformio.org/libraries/bojit/PlatformIO-FreeRTOS" target="_blank" rel="external nofollow">the PlatformIO library's readme</a>.
 :::
 
-In this tutorial, we will also use [CMSIS_RTOS_V2](https://arm-software.github.io/CMSIS_5/RTOS2/html/rtos_api2.html) to have a generic RTOS API. You will have to find the lib corresponding to your provider's and MCU. If you prefer to directly use FreeRTOS API, you will have to adapt the code of this tutorial, no big deal...
+In this tutorial, we will also use <a href="https://arm-software.github.io/CMSIS_5/RTOS2/html/rtos_api2.html" target="_blank" rel="external nofollow">CMSIS_RTOS_V2</a> to have a generic RTOS API. You will have to find the lib corresponding to your provider's and MCU. If you prefer to directly use FreeRTOS API, you will have to adapt the code of this tutorial, no big deal...
 
 :::info
-You can find a ST version in [our FreeRTOS example](https://github.com/Luos-io/luos_engine/tree/main/Examples/Projects/l0/Button_FreeRTOS). 
+You can find a ST version in <a href="https://github.com/Luos-io/luos_engine/tree/main/examples/projects/l0/button_freertos" target="_blank" rel="external nofollow">our FreeRTOS example</a>. 
 :::
 
 ## 3. FreeRTOS configurations
@@ -73,7 +73,7 @@ Working with Luos FreeRTOS doesn't require any specific configuration, except fo
 ```
 
 :::info
-If you want more information about the options displayed in _FreeRTOSConfig.h_, please check the [dedicated page](https://www.freertos.org/a00110.html).
+If you want more information about the options displayed in _FreeRTOSConfig.h_, please check the <a href="https://www.freertos.org/a00110.html" target="_blank" rel="external nofollow">dedicated page</a>.
 :::
 
 The only exception of this standard configuration is that Luos engine uses the systick value provided by the HAL of your ship (allowing Luos to work in a bare metal configuration). By default FreeRTOS will pre-empt this systick and manage its own. To keep Luos working we have to provide this systick value to the HAL level
@@ -82,9 +82,9 @@ You have three solutions to solve this:
 
  - You write the systick IRQ handler by yourself increment the HAL systick then call the RTOS systick function. (We use this solution on our examples)
  - You can override the weak HAL systick function and use the RTOS systick instead of the HAL one.
- - You can use the [RTOS hook](https://www.freertos.org/a00016.html) option calling a callback at each systick allowing you to increment the HAL systick manualy.
+ - You can use the <a href="https://www.freertos.org/a00016.html" target="_blank" rel="external nofollow">RTOS hook</a> option calling a callback at each systick allowing you to increment the HAL systick manualy.
 
-Now we have to call the kernel routines from our `main()` function. We could directly use FreeRTOS functions, but ARM defined a standard API to interface with RTOS capabilities called [CMSIS_RTOS_V2](https://arm-software.github.io/CMSIS_5/RTOS2/html/rtos_api2.html) and we will use it.
+Now we have to call the kernel routines from our `main()` function. We could directly use FreeRTOS functions, but ARM defined a standard API to interface with RTOS capabilities called <a href="https://arm-software.github.io/CMSIS_5/RTOS2/html/rtos_api2.html" target="_blank" rel="external nofollow">CMSIS_RTOS_V2</a> and we will use it.
 
 In our main, we have to remove all the Luos and services functions, becaus e we will transform them into tasks.
 Then we can call the OS API in our _main.c_ file:
@@ -200,7 +200,7 @@ One last thing, in each task routine, we call the service loop then we yield to 
 
 ## 5. Test your project
 
-To test your project you can add a pipe and Gate packages (you can find [available packages on the _Gate_SerialCom_ project corresponding to your board](https://github.com/Luos-io/luos_engine/tree/main/Examples/Projects)), add the code in the _lib/_ folder and instanciate it by creating a new task in _freertos.c_.
+To test your project you can add a pipe and Gate packages (you can find <a href="https://github.com/Luos-io/luos_engine/tree/main/examples/projects" target="_blank" rel="external nofollow">available packages on the _Gate_SerialCom_ project corresponding to your board</a>, add the code in the _lib/_ folder and instanciate it by creating a new task in _freertos.c_.
 
 Now you can build your project in VSCode and load it to your board. Once the board is flashed, you can use the `pyluos-shell` command on your computer to control your LED through python.
 

--- a/tutorials/get-started/get-started.mdx
+++ b/tutorials/get-started/get-started.mdx
@@ -22,7 +22,7 @@ import Introduction from '/src/components/school/article/intro.js';
   ressources={[
     {
       label: 'Arduino zero',
-      link: 'https://www.arduino.cc/en/Main/ArduinoBoardZero&',
+      link: 'https://docs.arduino.cc/hardware/zero',
     },
     {
       label: 'MKRzero',

--- a/tutorials/get-started/get-started1.mdx
+++ b/tutorials/get-started/get-started1.mdx
@@ -21,9 +21,9 @@ This part will guide you through the basic essential tools' installation and how
 
 ## 2. Set up your development environment
 
-We will use [PlatformIO](https://platformio.org/platformio-ide) as a development environment.
+We will use <a href="https://platformio.org/platformio-ide" target="_blank" rel="external nofollow">PlatformIO</a> as a development environment.
 
-1. First, download and install it following the [PlatformIO installation page](https://platformio.org/install/ide?install=vscode).
+1. First, download and install it following the <a href="https://platformio.org/install/ide?install=vscode" target="_blank" rel="external nofollow">PlatformIO installation page</a>.
 2. When it is done, open the VS Code editor.
 3. Through this Get started, you will need to enter some command lines in a terminal. You can either use the terminal from VS Code, or use your favorite one.
 
@@ -42,7 +42,7 @@ We will use [PlatformIO](https://platformio.org/platformio-ide) as a development
 
 ## 3. Download the base code
 
-Download and unzip [from this link](https://github.com/Luos-io/Get_started/archive/refs/heads/master.zip) the Get started base code.
+Download and unzip <a href="https://github.com/Luos-io/Get_started/archive/refs/heads/master.zip" target="_blank" rel="external nofollow">from this link</a> the Get started base code.
 
 :::tip
 Alternatively, you can clone this code through **Git** via the terminal, using the following command line:
@@ -51,7 +51,7 @@ Alternatively, you can clone this code through **Git** via the terminal, using t
 git clone https://github.com/Luos-io/Get_started.git
 ```
 
-You will need to have [GIT](https://git-scm.com/downloads) installed on your computer to do that. If you are not familiar with Git, you can consult [their documentation](https://git-scm.com/doc).
+You will need to have <a href="https://git-scm.com/downloads" target="_blank" rel="external nofollow">GIT</a> installed on your computer to do that. If you are not familiar with Git, you can consult <a href="https://git-scm.com/doc" target="_blank" rel="external nofollow">their documentation</a>.
 
 :::
 
@@ -126,12 +126,12 @@ Once the board is flashed, it means the compiled binary you created have been co
 
 :::tip
 In order to make this step to work, you may need to install the USB driver related to your board on your computer.
-Note: Linux users should give USB access to their boards by modifying the `udev rules` access rights. To give such rights to PlatformIO, please follow this [tutorial](https://docs.platformio.org/en/latest/faq.html#platformio-udev-rules) on PlatformIO FAQ section.
+Note: Linux users should give USB access to their boards by modifying the `udev rules` access rights. To give such rights to PlatformIO, please follow this <a href="https://docs.platformio.org/en/latest/faq.html#platformio-udev-rules" target="_blank" rel="external nofollow">tutorial</a> on PlatformIO FAQ section.
 
 :::
 
 :::warning
-If you have any trouble with your board's USB driver, you can consult **[our related troubleshooting page](/faq/dfu)**. Also, Make sure your USB cable is not faulty (it happens... 🤗).
+If you have any trouble with your board's USB driver, you can consult **[our related troubleshooting page](/faq/dfu)**. Also, Make sure your USB cable is not faulty (it happens... 🤗).
 
 :::
 

--- a/tutorials/get-started/get-started2.mdx
+++ b/tutorials/get-started/get-started2.mdx
@@ -30,7 +30,7 @@ pip install pyluos
 ```
 
 :::caution
-As you need to use a `pip` command in your terminal, [make sure to have a working pip environment](https://pip.pypa.io/en/stable/getting-started/).
+As you need to use a `pip` command in your terminal, <a href="https://pip.pypa.io/en/stable/getting-started/" target="_blank" rel="external nofollow">make sure to have a working pip environment</a>.
 
 :::
 
@@ -132,7 +132,7 @@ You can always check the list of the commands available for all services using y
   />
 </div>
 
-See [Pyluos](https://docs.luos.io/docs/tools/pyluos) documentation for more information.
+See [Pyluos](/docs/tools/pyluos) documentation for more information.
 
 :::
 

--- a/tutorials/get-started/get-started3.mdx
+++ b/tutorials/get-started/get-started3.mdx
@@ -283,7 +283,7 @@ device.blinker.play()
 ## Next steps
 
 :::info
-In this Get started tutorial, we used the default network used by Luos engine called Robus. The customization of your physical interface will be addressed in a future tutorial. The default hardware interface used by Robus is defined on the [Robus HAL](https://github.com/Luos-io/luos_engine/tree/main/network/robus/HAL) folder corresponding to your device.
+In this Get started tutorial, we used the default network used by Luos engine called Robus. The customization of your physical interface will be addressed in a future tutorial. The default hardware interface used by Robus is defined on the <a href="https://github.com/Luos-io/luos_engine/tree/main/network/robus/HAL" target="_blank" rel="external nofollow">Robus HAL</a> folder corresponding to your device.
 
 :::
 
@@ -293,4 +293,4 @@ The next step will show you how to visualize your network online through the Luo
 
 You can check out our [tutorials](/tutorials) to learn more about Luos and understand how to use the features of Luos engine. We also invite you to check out our [documentation](/docs/luos-technology) to learn more about the core concepts of Luos engine.
 
-⭐ If you liked this tutorial, feel free to star our [Luos engine repository](https://github.com/Luos-io/luos_engine ⭐
+⭐ If you liked this tutorial, feel free to star our <a href="https://github.com/Luos-io/luos_engine" target="_blank" rel="external nofollow">Luos engine repository</a>⭐

--- a/tutorials/get-started/get-started3.mdx
+++ b/tutorials/get-started/get-started3.mdx
@@ -283,7 +283,7 @@ device.blinker.play()
 ## Next steps
 
 :::info
-In this Get started tutorial, we used the default network used by Luos engine called Robus. The customization of your physical interface will be addressed in a future tutorial. The default hardware interface used by Robus is defined on the [Robus HAL](https://github.com/Luos-io/luos_engine/tree/main/Network/Robus/HAL) folder corresponding to your device.
+In this Get started tutorial, we used the default network used by Luos engine called Robus. The customization of your physical interface will be addressed in a future tutorial. The default hardware interface used by Robus is defined on the [Robus HAL](https://github.com/Luos-io/luos_engine/tree/main/network/robus/HAL) folder corresponding to your device.
 
 :::
 

--- a/tutorials/get-started/get-started4.mdx
+++ b/tutorials/get-started/get-started4.mdx
@@ -214,4 +214,4 @@ Now unplug the USB cable of Board 1 and connect the USB cable of board 2. Then f
 
 You can check out our [tutorials](/tutorials) in our Academy section to learn more about Luos and understand how to use the features of Luos technology. We also invite you to check out our [documentation](/docs/luos-technology) to learn more about the core concepts of Luos.
 
-⭐ If you liked this tutorial, feel free to star our [Luos repository](https://github.com/Luos-io/Luos) ⭐
+⭐ If you liked this tutorial, feel free to star our <a href="https://github.com/Luos-io/luos_engine" target="_blank" rel="external nofollow">Luos engine repository</a>⭐

--- a/tutorials/your-first-detection/your-first-detection.mdx
+++ b/tutorials/your-first-detection/your-first-detection.mdx
@@ -48,7 +48,7 @@ import Introduction from '/src/components/school/article/intro.js';
     },
     {
       label: 'MKR1000',
-      link: 'https://store.arduino.cc/collections/boards/products/arduino-mkr1000-wifi',
+      link: 'https://docs.arduino.cc/hardware/mkr-1000-wifi',
     },
     {
       label: 'STM32L432KC',

--- a/vercel.json
+++ b/vercel.json
@@ -37,6 +37,11 @@
       "statusCode": 301
     },
     {
+      "source": "/docs/luos-technology/luos_tech",
+      "destination": "/docs/luos-technology",
+      "statusCode": 301
+    },
+    {
       "source": "/docs/luos-technology/package/package",
       "destination": "/docs/luos-technology/package",
       "statusCode": 301
@@ -44,6 +49,11 @@
     {
       "source": "/docs/luos-technology/services/services",
       "destination": "/docs/luos-technology/services",
+      "statusCode": 301
+    },
+    {
+      "source": "/docs/next/luos-technology/luos_tech",
+      "destination": "/docs/next/luos-technology",
       "statusCode": 301
     },
     {
@@ -57,8 +67,18 @@
       "statusCode": 301
     },
     {
+      "source": "/docs/2.0.1/tools/tool",
+      "destination": "/docs/2.0.1/tools/",
+      "statusCode": 301
+    },
+    {
       "source": "/faq/list",
       "destination": "/faq",
+      "statusCode": 301
+    },
+    {
+      "source": "/faq/application-compile",
+      "destination": "/faq/application-does-not-compile",
       "statusCode": 301
     },
     {

--- a/vercel.json
+++ b/vercel.json
@@ -259,6 +259,11 @@
       "source": "/us/technology",
       "destination": "/",
       "statusCode": 301
+    },
+    {
+      "source": "/support",
+      "destination": "https://discord.gg/luos",
+      "statusCode": 301
     }
   ]
 }

--- a/versioned_docs/version-2.0.1/api/api-json.md
+++ b/versioned_docs/version-2.0.1/api/api-json.md
@@ -9,7 +9,7 @@ import Image from '/src/components/Images.js';
 
 <h1><a href="#json-api" className="header" id="json-api"><img src="/img/json-logo.png" width="80px" /> / JSON API</a></h1>
 
-The <a href="https://en.wikipedia.org/wiki/JSON" target="blank_">JSON formatted data</a> is common and widely used by many programming languages. Luos allows you to convert low-level Luos information into JSON objects, enabling conventional programming languages to interact with your device easily.
+The <a href="https://en.wikipedia.org/wiki/JSON" target="blank_" rel="external nofollow">JSON formatted data</a> is common and widely used by many programming languages. Luos allows you to convert low-level Luos information into JSON objects, enabling conventional programming languages to interact with your device easily.
 
 To do that, you must add a specific app service called a [gate](../tools/gate) on your device.
 
@@ -308,8 +308,8 @@ Parameters are defined by a 16-bit bitfield.
 
 |   Object   |               Definition               |                                                                         Structure                                                                         |            Service(s)            |
 | :--------: | :------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------------------------------------: | :------------------------------: |
-| parameters | enabling or disabling some measurement | [Link to structure (GitHub)](https://github.com/Luos-io/Examples/blob/master/Projects/l0/Controller_motor/lib/Controller_motor/controller_motor.h#L7-L31) | Stepper, Controller-motor, Servo |
-| parameters | enabling or disabling some measurement |             [Link to structure (GitHub)](https://github.com/Luos-io/Examples/blob/master/Projects/l0/Imu/lib/Imu/mpu_configuration.h#L37-L56)             |               Imu                |
+| parameters | enabling or disabling some measurement | [Link to structure (GitHub)](https://github.com/Luos-io/luos_engine/tree/main/examples/projects/l0/controller_motor) | Stepper, Controller-motor, Servo |
+| parameters | enabling or disabling some measurement |             [Link to structure (GitHub)](https://github.com/Luos-io/luos_engine/tree/main/examples/projects/l0/imu/lib/Imu)             |               Imu                |
 
 Other specific messages:
 

--- a/versioned_docs/version-2.0.1/hardware-consideration/electronics.mdx
+++ b/versioned_docs/version-2.0.1/hardware-consideration/electronics.mdx
@@ -15,7 +15,7 @@ To create and match with a default reference design, electronic boards must resp
 
 A Luos-friendly electronic board must contain _at least_ the following elements:
 
-- **1** <a href="https://en.wikipedia.org/wiki/Microcontroller" target="_blank">**MCU<IconExternalLink width="10"></IconExternalLink>**</a> (microcontroller unit): It hosts, as a node, the Luos firmware along with the different <Tooltip def={customFields.service_def} >services</Tooltip> (drivers and apps).
+- **1** <a href="https://en.wikipedia.org/wiki/Microcontroller" target="_blank" rel="external nofollow">**MCU<IconExternalLink width="10"></IconExternalLink>**</a> (microcontroller unit): It hosts, as a node, the Luos firmware along with the different <Tooltip def={customFields.service_def} >services</Tooltip> (drivers and apps).
 - **At least two connectors**: They allow to link boards together into a Luos network and link them as a daisy-chain or star mounting. Through PTP pins, nodes know if there is another node connected to the connector. This is used when the user wants to make a topology detection of the system.
 
 ## One-wire reference design
@@ -27,7 +27,7 @@ A Luos-friendly electronic board must contain _at least_ the following elements:
   />
 </div>
 
-Luos' One-wire official connector is <a href="https://octopart.com/df11-4dp-2ds%2852%29-hirose-261749" target="_blank">_DF11-4DP-2DS<IconExternalLink width="10"></IconExternalLink>_</a>.
+Luos' One-wire official connector is <a href="https://octopart.com/df11-4dp-2ds%2852%29-hirose-261749" target="_blank" rel="external nofollow">_DF11-4DP-2DS<IconExternalLink width="10"></IconExternalLink>_</a>.
 
 ## RS485 reference design
 
@@ -38,6 +38,6 @@ Luos' One-wire official connector is <a href="https://octopart.com/df11-4dp-2ds%
   />
 </div>
 
-Luos' RS485 official connector is <a href="https://octopart.com/df11-8dp-2ds%2824%29-hirose-39521447" target="_blank">_DF11-8DP-2DS<IconExternalLink width="10"></IconExternalLink>_</a>.
+Luos' RS485 official connector is <a href="https://octopart.com/df11-8dp-2ds%2824%29-hirose-39521447" target="_blank" rel="external nofollow">_DF11-8DP-2DS<IconExternalLink width="10"></IconExternalLink>_</a>.
 
-See the default pinout configuration in <a href="https://github.com/Luos-io/LuosHAL" target="_blank">_luos_hal_config.h<IconExternalLink width="10"></IconExternalLink>_</a> file for chosen the MCU family.
+See the default pinout configuration in <a href="https://github.com/Luos-io/LuosHAL" target="_blank" rel="external nofollow">_luos_hal_config.h<IconExternalLink width="10"></IconExternalLink>_</a> file for chosen the MCU family.

--- a/versioned_docs/version-2.0.1/hardware-consideration/hardware-consideration.mdx
+++ b/versioned_docs/version-2.0.1/hardware-consideration/hardware-consideration.mdx
@@ -6,8 +6,8 @@ import IconExternalLink from "@theme/IconExternalLink";
 
 # Hardware consideration
 
-When creating a Luos network, if you have a product with several nodes, it is mandatory to configure your MCU, to create the physical layer. In <a href="https://github.com/Luos-io/Examples/" target="_blank">Luos's examples on GitHub<IconExternalLink width="10"></IconExternalLink></a>, Luos uses RS485 with a driver or one-wire communication for this physical layer ([see Electronic design](./electronics) page), but other communication ways are possible.
+When creating a Luos network, if you have a product with several nodes, it is mandatory to configure your MCU, to create the physical layer. In <a href="https://github.com/Luos-io/luos_engine/tree/main/examples" target="_blank" rel="external nofollow">Luos's examples on GitHub<IconExternalLink width="10"></IconExternalLink></a>, Luos uses RS485 with a driver or one-wire communication for this physical layer ([see Electronic design](./electronics) page), but other communication ways are possible.
 
-Board examples and driver sources are available <a href="https://github.com/Luos-io/Examples/tree/master/Projects" target="_blank">on GitHub<IconExternalLink width="10"></IconExternalLink></a>. We encourage you to use them in the way you want.
+Board examples and driver sources are available <a href="https://github.com/Luos-io/luos_engine/tree/main/examples/projects" target="_blank" rel="external nofollow">on GitHub<IconExternalLink width="10"></IconExternalLink></a>. We encourage you to use them in the way you want.
 
-You can find the schematic of a Luos-ready board called L0 <a href="https://github.com/Luos-io/Examples/tree/master/Hardware/l0" target="_blank">on Github<IconExternalLink width="10"></IconExternalLink></a> for a quick hardware example.
+You can find the schematic of a Luos-ready board called L0 <a href="https://github.com/Luos-io/luos_engine/tree/main/examples/hardware/l0" target="_blank" rel="external nofollow">on Github<IconExternalLink width="10"></IconExternalLink></a> for a quick hardware example.

--- a/versioned_docs/version-2.0.1/hardware-consideration/test-your-configuration.mdx
+++ b/versioned_docs/version-2.0.1/hardware-consideration/test-your-configuration.mdx
@@ -1,7 +1,7 @@
 # Test your hardware configuration
 
 To adapt Luos to your board specificities, you need to configure it. This subject is covered in the [Luos configuration](./mcu).
-To validate your network hardware configuration, you can use a Luos tool called selftest available in the <a href="https://github.com/Luos-io/Luos" target="_blank">Luos Library<IconExternalLink width="10"></IconExternalLink></a>.
+To validate your network hardware configuration, you can use a Luos tool called selftest available in the <a href="https://github.com/Luos-io/luos_engine/tree/main/network/robus/selftest" target="_blank" rel="external nofollow">Luos Library<IconExternalLink width="10"></IconExternalLink></a>.
 
 ## Hardware test conditions
 

--- a/versioned_docs/version-2.0.1/luos-technology/basics/basics.mdx
+++ b/versioned_docs/version-2.0.1/luos-technology/basics/basics.mdx
@@ -19,7 +19,7 @@ Luos is here to back you up and keep your projects clean and smooth to develop, 
 
 ## Introduction to Luos
 
-**Luos is a simple and lightweight containerization platform dedicated to embedded systems enabling a <a href="https://en.wikipedia.org/wiki/Microservices" target="_blank">microservices<IconExternalLink width="10"></IconExternalLink></a> architecture for electronics.** It is a powerful modularity tool to simplify and link any hardware component or application code together as a <a href="https://en.wikipedia.org/wiki/Single_system_image" target="_blank">single system image<IconExternalLink width="10"></IconExternalLink></a>.
+**Luos is a simple and lightweight containerization platform dedicated to embedded systems enabling a <a href="https://en.wikipedia.org/wiki/Microservices" target="_blank" rel="external nofollow">microservices<IconExternalLink width="10"></IconExternalLink></a> architecture for electronics.** It is a powerful modularity tool to simplify and link any hardware component or application code together as a <a href="https://en.wikipedia.org/wiki/Single_system_image" target="_blank" rel="external nofollow">single system image<IconExternalLink width="10"></IconExternalLink></a>.
 
 This guide contains all the basic notions you will need to use, create and understand Luos technology.
 

--- a/versioned_docs/version-2.0.1/luos-technology/basics/concept.md
+++ b/versioned_docs/version-2.0.1/luos-technology/basics/concept.md
@@ -31,7 +31,7 @@ Services, much like their server-world counterparts, can be placed anywhere in y
 
 **Each service is hosted in a single node**, but you can have the same service duplicated multiple times in your product.
 
-For example, the Dynamixel example (available in the [GitHub example repository](https://github.com/Luos-io/Examples)) can dynamically create servomotors services depending on the number of Dynamixel motors linked to it. Any Dynamixel services are visible as independent servomotors similar to any other servomotor technology such as the stepper service example, or the controller motor service example. Then, you can use any of your Dynamixel from any other services or even from any computer, cloud program, or ecosystem such as ROS.
+For example, the Dynamixel example (available in the <a href="https://github.com/Luos-io/luos_engine/tree/main/examples" target ="_blank" rel="external nofollow">Luos engine example folder</a>) can dynamically create servomotors services depending on the number of Dynamixel motors linked to it. Any Dynamixel services are visible as independent servomotors similar to any other servomotor technology such as the stepper service example, or the controller motor service example. Then, you can use any of your Dynamixel from any other services or even from any computer, cloud program, or ecosystem such as ROS.
 
 There are two categories of services, [drivers](../services/service-api#drivers-guidelines) or [applications](../services/service-api#apps-guidelines).
 

--- a/versioned_docs/version-2.0.1/luos-technology/luos_tech.md
+++ b/versioned_docs/version-2.0.1/luos-technology/luos_tech.md
@@ -13,9 +13,7 @@ Luos is an open-source lightweight library that can be used on any MCU, leading 
 
 Most of the embedded developments are made from scratch. By using Luos, you will be able to capitalize on the development you, your company, or the Luos community already did. The re-usability of features encapsulated in Luos services will fasten the time your products reach the market and reassure the robustness and the universality of your applications.
 
-You can visit the <a href="https://www.reddit.com/r/Luos/" target ="_blank">Luos community on Reddit</a>.
-
-Need dedicated help with your project? <a href="https://www.luos.io/support" target ="_blank">Check out Luos' support packages</a>.
+Need dedicated help for your project? You can join the Luos community on <a href="https://discord.gg/luos" target ="_blank" rel="external nofollow">Discord</a> or <a href="https://www.reddit.com/r/Luos/" target ="_blank" rel="external nofollow">Reddit</a>.
 
 ## Good practices with Luos
 

--- a/versioned_docs/version-2.0.1/luos-technology/message/command.mdx
+++ b/versioned_docs/version-2.0.1/luos-technology/message/command.mdx
@@ -94,6 +94,6 @@ User's commands start at `LUOS_LAST_RESERVED_CMD`.
 | PARAMETERS | depends on the service. It can be: servo_parameters_t, imu_report_t, motor_mode_t |
 | ERROR_CMD  |                                                                                   |
 
-You can find the complete list of commands <a href="https://github.com/Luos-io/Luos/blob/master/inc/luos_list.h" target = "_blank">here<IconExternalLink width="10"></IconExternalLink></a>.
+You can find the complete list of commands <a href="https://github.com/Luos-io/luos_engine/blob/main/engine/core/inc/luos_list.h" target= "_blank" rel="external nofollow">here<IconExternalLink width="10"></IconExternalLink></a>.
 
 If you want to create new commands for your custom services, you can create and add your own starting at `LUOS_LAST_STD_CMD`. [See how](/tutorials).

--- a/versioned_docs/version-2.0.1/luos-technology/node/luos.mdx
+++ b/versioned_docs/version-2.0.1/luos-technology/node/luos.mdx
@@ -15,13 +15,13 @@ The node's embedded code hosts the Luos's embedded code and the node's various f
 
 Luos works as a code library running on nodes. To match the Luos library with your hardware, Luos offers a _Hardware Abstraction Layer_ for various devices in <Tooltip def={customFields.luoshal_def}>LuosHAL</Tooltip>.
 
-- <a href="https://github.com/Luos-io/LuosHAL" target="_blank">
+- <a href="https://github.com/Luos-io/LuosHAL" target="_blank" rel="external nofollow">
     LuosHAL
     <IconExternalLink width="10"></IconExternalLink>
   </a>
   : This repository provides a list of family devices covered to match the Luos library
   with your hardware.
-- <a href="https://github.com/Luos-io/Luos" target="_blank">
+- <a href="https://github.com/Luos-io/Luos" target="_blank" rel="external nofollow">
     Luos
     <IconExternalLink width="10"></IconExternalLink>
   </a>
@@ -94,11 +94,11 @@ You can use it to set all your custom configurations:
 |     MAX_MSG_NB     | 2\*MAX_SERVICE_NUMBER |                               Max number of messages that can be referenced by Luos.                               |
 |      NBR_PORT      |           2           | Number of PTP (port) on the node ( max 8). See [electronic design](../../hardware-consideration/electronics) page. |
 
-You will find the default configuration for Luos Library in the file <a href="https://github.com/Luos-io/Luos/tree/master/Robus/inc/config.h" target="_blank">config.h<IconExternalLink width="10"></IconExternalLink></a>,
+You will find the default configuration for Luos Library in the file <a href="https://github.com/Luos-io/luos_engine/blob/main/network/robus/inc/config.h" target="_blank" rel="external nofollow">config.h<IconExternalLink width="10"></IconExternalLink></a>,
 
 Check the Luos_hal_config.h of your MCU family to see parameters that can be changed to fit your design.
 
-> **Note:** [Every example](https://github.com/Luos-io/Examples) provided by Luos has a _node_config.h_ file that can be used as a base to fit your project's needs.
+> **Note:** <a href="https://github.com/Luos-io/luos_engine/tree/main/examples" target="_blank" rel="external nofollow">Every example</a> provided by Luos has a _node_config.h_ file that can be used as a base to fit your project's needs.
 
 ## Luos Statistics
 

--- a/versioned_docs/version-2.0.1/luos-technology/services/profile.md
+++ b/versioned_docs/version-2.0.1/luos-technology/services/profile.md
@@ -13,7 +13,7 @@ The profile handles messaging to share your variables with other services. Moreo
 > **Example:** If you want to make a servo-motor service, you have to select the servo-motor profile for your service and use variables of the profile structure to set the rotor current position measurement, or to get the current motor target in your code.
 
 Profiles are convenient for making your code clean and straightforward, complying with your development into a standard API, or sharing your service type with the community.
-Luos provides some common profile models that you can use; feel free to contribute and to add your own to the standard profile bank with a pull request on <a href="https://github.com/Luos-io" target="_blank">Luos' GitHub page &#8599;</a>.
+Luos provides some common profile models that you can use; feel free to contribute and to add your own to the standard profile bank with a pull request on <a href="https://github.com/Luos-io" target="_blank" rel="external nofollow">Luos' GitHub page &#8599;</a>.
 
 ## How to use a profile in your service
 
@@ -64,4 +64,4 @@ void Button_Loop(void) {
 }
 ```
 
-You can notice that you don't send any Luos message to share the button state: if an application wants to access this information, the state profile will share it for you. You only have to update the button state value in your code. Supported profiles are available in this [repository](https://github.com/Luos-io/Luos/tree/master/Profiles).
+You can notice that you don't send any Luos message to share the button state: if an application wants to access this information, the state profile will share it for you. You only have to update the button state value in your code. Supported profiles are available in this <a href="https://github.com/Luos-io/luos_engine/tree/main/engine/profiles" target ="_blank" rel="external nofollow">repository</a>.

--- a/versioned_docs/version-2.0.1/tools/boot.md
+++ b/versioned_docs/version-2.0.1/tools/boot.md
@@ -166,11 +166,7 @@ Examples are available for several IDEs: L4 / F4 / F0 uses platformIO, G4 uses S
 
 #### Luos does not yet support your target:
 
-First of all, you have to **enable the bootloader feature** in the Luos library. To do so, you have to add the **-D BOOTLOADER_CONFIG** parameter when you invoke your compiler. Then you have to run the library in your main() function as you would do for any project:
-
-<div align="center">
-  <Image src="/img/main_bootloader.png"/>
-</div>
+First of all, you have to **enable the bootloader feature** in the Luos library. To do so, you have to add the **-D BOOTLOADER_CONFIG** parameter when you invoke your compiler. Then you have to run the library in your main() function as you would do for any project.
 
 > **Warning**: Luos will now run the bootloader application. Be careful not to initialize any package with the **ADD_PACKAGE()** macro. Luos can only run the bootloader app in bootloader mode, and your package will not be executed.
 

--- a/versioned_docs/version-2.1.0/api/api-json.md
+++ b/versioned_docs/version-2.1.0/api/api-json.md
@@ -9,7 +9,7 @@ import Image from '/src/components/Images.js';
 
 <h1><a href="#json-api" className="header" id="json-api"><img src="/img/json-logo.png" width="80px" /> / JSON API</a></h1>
 
-The <a href="https://en.wikipedia.org/wiki/JSON" target="blank_">JSON formatted data</a> is common and widely used by many programming languages. Luos allows you to convert low-level Luos information into JSON objects, enabling conventional programming languages to interact with your device easily.
+The <a href="https://en.wikipedia.org/wiki/JSON" target="blank_" rel="external nofollow">JSON formatted data</a> is common and widely used by many programming languages. Luos allows you to convert low-level Luos information into JSON objects, enabling conventional programming languages to interact with your device easily.
 
 To do that, you must add a specific app service called a [gate](../tools/gate) on your device.
 
@@ -308,8 +308,8 @@ Parameters are defined by a 16-bit bitfield.
 
 |   Object   |               Definition               |                                                                         Structure                                                                         |            Service(s)            |
 | :--------: | :------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------------------------------------: | :------------------------------: |
-| parameters | enabling or disabling some measurement | [Link to structure (GitHub)](https://github.com/Luos-io/Examples/blob/master/Projects/l0/Controller_motor/lib/Controller_motor/controller_motor.h#L7-L31) | Stepper, Controller-motor, Servo |
-| parameters | enabling or disabling some measurement |             [Link to structure (GitHub)](https://github.com/Luos-io/Examples/blob/master/Projects/l0/Imu/lib/Imu/mpu_configuration.h#L37-L56)             |               Imu                |
+| parameters | enabling or disabling some measurement | [Link to structure (GitHub)](https://github.com/Luos-io/luos_engine/tree/main/examples/projects/l0/controller_motor) | Stepper, Controller-motor, Servo |
+| parameters | enabling or disabling some measurement |             [Link to structure (GitHub)](https://github.com/Luos-io/luos_engine/tree/main/examples/projects/l0/imu/lib/Imu)             |               Imu                |
 
 Other specific messages:
 

--- a/versioned_docs/version-2.1.0/hardware-consideration/electronics.mdx
+++ b/versioned_docs/version-2.1.0/hardware-consideration/electronics.mdx
@@ -15,7 +15,7 @@ To create and match with a default reference design, electronic boards must resp
 
 A Luos-friendly electronic board must contain _at least_ the following elements:
 
-- **1** <a href="https://en.wikipedia.org/wiki/Microcontroller" target="_blank">**MCU<IconExternalLink width="10"></IconExternalLink>**</a> (microcontroller unit): It hosts, as a node, the Luos firmware along with the different <Tooltip def={customFields.service_def} >services</Tooltip> (drivers and apps).
+- **1** <a href="https://en.wikipedia.org/wiki/Microcontroller" target="_blank" rel="external nofollow">**MCU<IconExternalLink width="10"></IconExternalLink>**</a> (microcontroller unit): It hosts, as a node, the Luos firmware along with the different <Tooltip def={customFields.service_def} >services</Tooltip> (drivers and apps).
 - **At least two connectors**: They allow to link boards together into a Luos network and link them as a daisy-chain or star mounting. Through PTP pins, nodes know if there is another node connected to the connector. This is used when the user wants to make a topology detection of the system.
 
 ## One-wire reference design
@@ -27,7 +27,7 @@ A Luos-friendly electronic board must contain _at least_ the following elements:
   />
 </div>
 
-Luos' One-wire official connector is <a href="https://octopart.com/df11-4dp-2ds%2852%29-hirose-261749" target="_blank">_DF11-4DP-2DS<IconExternalLink width="10"></IconExternalLink>_</a>.
+Luos' One-wire official connector is <a href="https://octopart.com/df11-4dp-2ds%2852%29-hirose-261749" target="_blank" rel="external nofollow">_DF11-4DP-2DS<IconExternalLink width="10"></IconExternalLink>_</a>.
 
 ## RS485 reference design
 
@@ -38,6 +38,6 @@ Luos' One-wire official connector is <a href="https://octopart.com/df11-4dp-2ds%
   />
 </div>
 
-Luos' RS485 official connector is <a href="https://octopart.com/df11-8dp-2ds%2824%29-hirose-39521447" target="_blank">_DF11-8DP-2DS<IconExternalLink width="10"></IconExternalLink>_</a>.
+Luos' RS485 official connector is <a href="https://octopart.com/df11-8dp-2ds%2824%29-hirose-39521447" target="_blank" rel="external nofollow">_DF11-8DP-2DS<IconExternalLink width="10"></IconExternalLink>_</a>.
 
-See the default pinout configuration in <a href="https://github.com/Luos-io/LuosHAL" target="_blank">_luos_hal_config.h<IconExternalLink width="10"></IconExternalLink>_</a> file for chosen the MCU family.
+See the default pinout configuration in <a href="https://github.com/Luos-io/LuosHAL" target="_blank" rel="external nofollow">_luos_hal_config.h<IconExternalLink width="10"></IconExternalLink>_</a> file for chosen the MCU family.

--- a/versioned_docs/version-2.1.0/hardware-consideration/hardware-consideration.mdx
+++ b/versioned_docs/version-2.1.0/hardware-consideration/hardware-consideration.mdx
@@ -6,8 +6,8 @@ import IconExternalLink from "@theme/IconExternalLink";
 
 # Hardware consideration
 
-When creating a Luos network, if you have a product with several nodes, it is mandatory to configure your MCU, to create the physical layer. In <a href="https://github.com/Luos-io/Examples/" target="_blank">Luos's examples on GitHub<IconExternalLink width="10"></IconExternalLink></a>, Luos uses RS485 with a driver or one-wire communication for this physical layer ([see Electronic design](./electronics) page), but other communication ways are possible.
+When creating a Luos network, if you have a product with several nodes, it is mandatory to configure your MCU, to create the physical layer. In <a href="https://github.com/Luos-io/luos_engine/tree/main/examples" target="_blank" rel="external nofollow">Luos's examples on GitHub<IconExternalLink width="10"></IconExternalLink></a>, Luos uses RS485 with a driver or one-wire communication for this physical layer ([see Electronic design](./electronics) page), but other communication ways are possible.
 
-Board examples and driver sources are available <a href="https://github.com/Luos-io/Examples/tree/master/Projects" target="_blank">on GitHub<IconExternalLink width="10"></IconExternalLink></a>. We encourage you to use them in the way you want.
+Board examples and driver sources are available <a href="https://github.com/Luos-io/luos_engine/tree/main/examples/projects" target="_blank" rel="external nofollow">on GitHub<IconExternalLink width="10"></IconExternalLink></a>. We encourage you to use them in the way you want.
 
-You can find the schematic of a Luos-ready board called L0 <a href="https://github.com/Luos-io/Examples/tree/master/Hardware/l0" target="_blank">on Github<IconExternalLink width="10"></IconExternalLink></a> for a quick hardware example.
+You can find the schematic of a Luos-ready board called L0 <a href="https://github.com/Luos-io/luos_engine/tree/main/examples/hardware/l0" target="_blank" rel="external nofollow">on Github<IconExternalLink width="10"></IconExternalLink></a> for a quick hardware example.

--- a/versioned_docs/version-2.1.0/hardware-consideration/test-your-configuration.mdx
+++ b/versioned_docs/version-2.1.0/hardware-consideration/test-your-configuration.mdx
@@ -1,7 +1,7 @@
 # Test your hardware configuration
 
 To adapt Luos to your board specificities, you need to configure it. This subject is covered in the [Luos configuration](./mcu).
-To validate your network hardware configuration, you can use a Luos tool called selftest available in the <a href="https://github.com/Luos-io/Luos" target="_blank">Luos Library<IconExternalLink width="10"></IconExternalLink></a>.
+To validate your network hardware configuration, you can use a Luos tool called selftest available in the <a href="https://github.com/Luos-io/luos_engine" target="_blank" rel="external nofollow">Luos Library<IconExternalLink width="10"></IconExternalLink></a>.
 
 ## Hardware test conditions
 

--- a/versioned_docs/version-2.1.0/luos-technology/basics/basics.mdx
+++ b/versioned_docs/version-2.1.0/luos-technology/basics/basics.mdx
@@ -19,7 +19,7 @@ Luos is here to back you up and keep your projects clean and smooth to develop, 
 
 ## Introduction to Luos
 
-**Luos is a simple and lightweight containerization platform dedicated to embedded systems enabling a <a href="https://en.wikipedia.org/wiki/Microservices" target="_blank">microservices<IconExternalLink width="10"></IconExternalLink></a> architecture for electronics.** It is a powerful modularity tool to simplify and link any hardware component or application code together as a <a href="https://en.wikipedia.org/wiki/Single_system_image" target="_blank">single system image<IconExternalLink width="10"></IconExternalLink></a>.
+**Luos is a simple and lightweight containerization platform dedicated to embedded systems enabling a <a href="https://en.wikipedia.org/wiki/Microservices" target="_blank" rel="external nofollow">microservices<IconExternalLink width="10"></IconExternalLink></a> architecture for electronics.** It is a powerful modularity tool to simplify and link any hardware component or application code together as a <a href="https://en.wikipedia.org/wiki/Single_system_image" target="_blank" rel="external nofollow">single system image<IconExternalLink width="10"></IconExternalLink></a>.
 
 This guide contains all the basic notions you will need to use, create and understand Luos technology.
 

--- a/versioned_docs/version-2.1.0/luos-technology/basics/concept.md
+++ b/versioned_docs/version-2.1.0/luos-technology/basics/concept.md
@@ -31,7 +31,7 @@ Services, much like their server-world counterparts, can be placed anywhere in y
 
 **Each service is hosted in a single node**, but you can have the same service duplicated multiple times in your product.
 
-For example, the Dynamixel example (available in the [GitHub example repository](https://github.com/Luos-io/Examples)) can dynamically create servomotors services depending on the number of Dynamixel motors linked to it. Any Dynamixel services are visible as independent servomotors similar to any other servomotor technology such as the stepper service example, or the controller motor service example. Then, you can use any of your Dynamixel from any other services or even from any computer, cloud program, or ecosystem such as ROS.
+For example, the Dynamixel example (available in the <a href="https://github.com/Luos-io/luos_engine/tree/main/examples" target ="_blank" rel="external nofollow">Luos engine example folder</a>) can dynamically create servomotors services depending on the number of Dynamixel motors linked to it. Any Dynamixel services are visible as independent servomotors similar to any other servomotor technology such as the stepper service example, or the controller motor service example. Then, you can use any of your Dynamixel from any other services or even from any computer, cloud program, or ecosystem such as ROS.
 
 There are two categories of services, [drivers](../services/service-api#drivers-guidelines) or [applications](../services/service-api#apps-guidelines).
 

--- a/versioned_docs/version-2.1.0/luos-technology/luos_tech.md
+++ b/versioned_docs/version-2.1.0/luos-technology/luos_tech.md
@@ -13,9 +13,7 @@ Luos is an open-source lightweight library that can be used on any MCU, leading 
 
 Most of the embedded developments are made from scratch. By using Luos, you will be able to capitalize on the development you, your company, or the Luos community already did. The re-usability of features encapsulated in Luos services will fasten the time your products reach the market and reassure the robustness and the universality of your applications.
 
-You can visit the <a href="https://www.reddit.com/r/Luos/" target ="_blank">Luos community on Reddit</a>.
-
-Need dedicated help with your project? <a href="https://www.luos.io/support" target ="_blank">Check out Luos' support packages</a>.
+Need dedicated help for your project? You can join the Luos community on <a href="https://discord.gg/luos" target ="_blank" rel="external nofollow">Discord</a> or <a href="https://www.reddit.com/r/Luos/" target ="_blank" rel="external nofollow">Reddit</a>.
 
 ## Good practices with Luos
 

--- a/versioned_docs/version-2.1.0/luos-technology/message/command.mdx
+++ b/versioned_docs/version-2.1.0/luos-technology/message/command.mdx
@@ -94,6 +94,6 @@ User's commands start at `LUOS_LAST_RESERVED_CMD`.
 | PARAMETERS | depends on the service. It can be: servo_parameters_t, imu_report_t, motor_mode_t |
 | ERROR_CMD  |                                                                                   |
 
-You can find the complete list of commands <a href="https://github.com/Luos-io/Luos/blob/master/inc/luos_list.h" target = "_blank">here<IconExternalLink width="10"></IconExternalLink></a>.
+You can find the complete list of commands <a href="https://github.com/Luos-io/luos_engine/blob/main/engine/core/inc/luos_list.h" target= "_blank" rel="external nofollow">here<IconExternalLink width="10"></IconExternalLink></a>.
 
 If you want to create new commands for your custom services, you can create and add your own starting at `LUOS_LAST_STD_CMD`. [See how](/tutorials).

--- a/versioned_docs/version-2.1.0/luos-technology/node/luos.mdx
+++ b/versioned_docs/version-2.1.0/luos-technology/node/luos.mdx
@@ -15,13 +15,13 @@ The node's embedded code hosts the Luos's embedded code and the node's various f
 
 Luos works as a code library running on nodes. To match the Luos library with your hardware, Luos offers a _Hardware Abstraction Layer_ for various devices in <Tooltip def={customFields.luoshal_def}>LuosHAL</Tooltip>.
 
-- <a href="https://github.com/Luos-io/LuosHAL" target="_blank">
+- <a href="https://github.com/Luos-io/LuosHAL" target="_blank" rel="external nofollow">
     LuosHAL
     <IconExternalLink width="10"></IconExternalLink>
   </a>
   : This repository provides a list of family devices covered to match the Luos library
   with your hardware.
-- <a href="https://github.com/Luos-io/Luos" target="_blank">
+- <a href="https://github.com/Luos-io/Luos" target="_blank" rel="external nofollow">
     Luos
     <IconExternalLink width="10"></IconExternalLink>
   </a>
@@ -94,11 +94,11 @@ You can use it to set all your custom configurations:
 |     MAX_MSG_NB     | 2\*MAX_SERVICE_NUMBER |                               Max number of messages that can be referenced by Luos.                               |
 |      NBR_PORT      |           2           | Number of PTP (port) on the node ( max 8). See [electronic design](../../hardware-consideration/electronics) page. |
 
-You will find the default configuration for Luos Library in the file <a href="https://github.com/Luos-io/Luos/tree/master/Robus/inc/config.h" target="_blank">config.h<IconExternalLink width="10"></IconExternalLink></a>,
+You will find the default configuration for Luos Library in the file <a href="https://github.com/Luos-io/luos_engine/blob/main/network/robus/inc/config.h" target="_blank" rel="external nofollow">config.h<IconExternalLink width="10"></IconExternalLink></a>,
 
 Check the Luos_hal_config.h of your MCU family to see parameters that can be changed to fit your design.
 
-> **Note:** [Every example](https://github.com/Luos-io/Examples) provided by Luos has a _node_config.h_ file that can be used as a base to fit your project's needs.
+> **Note:** <a href="https://github.com/Luos-io/luos_engine/tree/main/examples" target="_blank" rel="external nofollow">Every example</a> provided by Luos has a _node_config.h_ file that can be used as a base to fit your project's needs.
 
 ## Luos Statistics
 

--- a/versioned_docs/version-2.1.0/luos-technology/services/profile.md
+++ b/versioned_docs/version-2.1.0/luos-technology/services/profile.md
@@ -13,7 +13,7 @@ The profile handles messaging to share your variables with other services. Moreo
 > **Example:** If you want to make a servo-motor service, you have to select the servo-motor profile for your service and use variables of the profile structure to set the rotor current position measurement, or to get the current motor target in your code.
 
 Profiles are convenient for making your code clean and straightforward, complying with your development into a standard API, or sharing your service type with the community.
-Luos provides some common profile models that you can use; feel free to contribute and to add your own to the standard profile bank with a pull request on <a href="https://github.com/Luos-io" target="_blank">Luos' GitHub page &#8599;</a>.
+Luos provides some common profile models that you can use; feel free to contribute and to add your own to the standard profile bank with a pull request on <a href="https://github.com/Luos-io" target="_blank" rel="external nofollow">Luos' GitHub page &#8599;</a>.
 
 ## How to use a profile in your service
 
@@ -64,4 +64,4 @@ void Button_Loop(void) {
 }
 ```
 
-You can notice that you don't send any Luos message to share the button state: if an application wants to access this information, the state profile will share it for you. You only have to update the button state value in your code. Supported profiles are available in this [repository](https://github.com/Luos-io/Luos/tree/master/Profiles).
+You can notice that you don't send any Luos message to share the button state: if an application wants to access this information, the state profile will share it for you. You only have to update the button state value in your code. Supported profiles are available in this <a href="https://github.com/Luos-io/luos_engine/tree/main/engine/profiles" target ="_blank" rel="external nofollow">repository</a>.

--- a/versioned_docs/version-2.1.0/tools/boot.md
+++ b/versioned_docs/version-2.1.0/tools/boot.md
@@ -166,11 +166,7 @@ Examples are available for several IDEs: L4 / F4 / F0 uses platformIO, G4 uses S
 
 #### Luos does not yet support your target:
 
-First of all, you have to **enable the bootloader feature** in the Luos library. To do so, you have to add the **-D BOOTLOADER_CONFIG** parameter when you invoke your compiler. Then you have to run the library in your main() function as you would do for any project:
-
-<div align="center">
-  <Image src="/img/main_bootloader.png"/>
-</div>
+First of all, you have to **enable the bootloader feature** in the Luos library. To do so, you have to add the **-D BOOTLOADER_CONFIG** parameter when you invoke your compiler. Then you have to run the library in your main() function as you would do for any project.
 
 > **Warning**: Luos will now run the bootloader application. Be careful not to initialize any package with the **ADD_PACKAGE()** macro. Luos can only run the bootloader app in bootloader mode, and your package will not be executed.
 

--- a/versioned_docs/version-2.2.0/api/api-json.mdx
+++ b/versioned_docs/version-2.2.0/api/api-json.mdx
@@ -13,7 +13,7 @@ import Image from '@site/src/components/Images.js';
   </a>
 </h1>
 
-The <a href="https://en.wikipedia.org/wiki/JSON" target="blank_">JSON formatted data</a> is common and widely used by many programming languages. Luos allows you to convert low-level Luos information into JSON objects, enabling conventional programming languages to interact with your device easily.
+The <a href="https://en.wikipedia.org/wiki/JSON" target="blank_" rel="external nofollow">JSON formatted data</a> is common and widely used by many programming languages. Luos allows you to convert low-level Luos information into JSON objects, enabling conventional programming languages to interact with your device easily.
 
 To do that, you must add a specific app service called a [gate](../tools/gate) on your device.
 
@@ -312,8 +312,8 @@ Parameters are defined by a 16-bit bitfield.
 
 |   Object   |               Definition               |                                                                         Structure                                                                         |            Service(s)            |
 | :--------: | :------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------------------------------------: | :------------------------------: |
-| parameters | enabling or disabling some measurement | [Link to structure (GitHub)](https://github.com/Luos-io/Examples/blob/master/Projects/l0/Controller_motor/lib/Controller_motor/controller_motor.h#L7-L31) | Stepper, Controller-motor, Servo |
-| parameters | enabling or disabling some measurement |             [Link to structure (GitHub)](https://github.com/Luos-io/Examples/blob/master/Projects/l0/Imu/lib/Imu/mpu_configuration.h#L37-L56)             |               Imu                |
+| parameters | enabling or disabling some measurement | [Link to structure (GitHub)](https://github.com/Luos-io/luos_engine/tree/main/examples/projects/l0/controller_motor) | Stepper, Controller-motor, Servo |
+| parameters | enabling or disabling some measurement |             [Link to structure (GitHub)](https://github.com/Luos-io/luos_engine/tree/main/examples/projects/l0/imu/lib/Imu)             |               Imu                |
 
 Other specific messages:
 

--- a/versioned_docs/version-2.2.0/hardware-consideration/electronics.mdx
+++ b/versioned_docs/version-2.2.0/hardware-consideration/electronics.mdx
@@ -15,7 +15,7 @@ To create and match with a default reference design, electronic boards must resp
 
 A Luos-friendly electronic board must contain _at least_ the following elements:
 
-- **1** <a href="https://en.wikipedia.org/wiki/Microcontroller" target="_blank">**MCU<IconExternalLink width="10"></IconExternalLink>**</a> (microcontroller unit): It hosts, as a node, the Luos firmware along with the different <Tooltip def={customFields.service_def} >services</Tooltip> (drivers and apps).
+- **1** <a href="https://en.wikipedia.org/wiki/Microcontroller" target="_blank" rel="external nofollow">**MCU<IconExternalLink width="10"></IconExternalLink>**</a> (microcontroller unit): It hosts, as a node, the Luos firmware along with the different <Tooltip def={customFields.service_def} >services</Tooltip> (drivers and apps).
 - **At least two connectors**: They allow to link boards together into a Luos network and link them as a daisy-chain or star mounting. Through PTP pins, nodes know if there is another node connected to the connector. This is used when the user wants to make a topology detection of the system.
 
 ## One-wire reference design
@@ -27,7 +27,7 @@ A Luos-friendly electronic board must contain _at least_ the following elements:
   />
 </div>
 
-Luos' One-wire official connector is <a href="https://octopart.com/df11-4dp-2ds%2852%29-hirose-261749" target="_blank">_DF11-4DP-2DS<IconExternalLink width="10"></IconExternalLink>_</a>.
+Luos' One-wire official connector is <a href="https://octopart.com/df11-4dp-2ds%2852%29-hirose-261749" target="_blank" rel="external nofollow">_DF11-4DP-2DS<IconExternalLink width="10"></IconExternalLink>_</a>.
 
 ## RS485 reference design
 
@@ -38,6 +38,6 @@ Luos' One-wire official connector is <a href="https://octopart.com/df11-4dp-2ds%
   />
 </div>
 
-Luos' RS485 official connector is <a href="https://octopart.com/df11-8dp-2ds%2824%29-hirose-39521447" target="_blank">_DF11-8DP-2DS<IconExternalLink width="10"></IconExternalLink>_</a>.
+Luos' RS485 official connector is <a href="https://octopart.com/df11-8dp-2ds%2824%29-hirose-39521447" target="_blank" rel="external nofollow">_DF11-8DP-2DS<IconExternalLink width="10"></IconExternalLink>_</a>.
 
-See the default pinout configuration in <a href="https://github.com/Luos-io/LuosHAL" target="_blank">_luos_hal_config.h<IconExternalLink width="10"></IconExternalLink>_</a> file for chosen the MCU family.
+See the default pinout configuration in <a href="https://github.com/Luos-io/LuosHAL" target="_blank" rel="external nofollow">_luos_hal_config.h<IconExternalLink width="10"></IconExternalLink>_</a> file for chosen the MCU family.

--- a/versioned_docs/version-2.2.0/hardware-consideration/hardware-consideration.mdx
+++ b/versioned_docs/version-2.2.0/hardware-consideration/hardware-consideration.mdx
@@ -6,8 +6,8 @@ import IconExternalLink from "@theme/IconExternalLink";
 
 # Hardware consideration
 
-When creating a Luos network, if you have a product with several nodes, it is mandatory to configure your MCU, to create the physical layer. In <a href="https://github.com/Luos-io/Examples/" target="_blank">Luos's examples on GitHub<IconExternalLink width="10"></IconExternalLink></a>, Luos uses RS485 with a driver or one-wire communication for this physical layer ([see Electronic design](./electronics) page), but other communication ways are possible.
+When creating a Luos network, if you have a product with several nodes, it is mandatory to configure your MCU, to create the physical layer. In <a href="https://github.com/Luos-io/luos_engine/tree/main/examples" target="_blank" rel="external nofollow">Luos's examples on GitHub<IconExternalLink width="10"></IconExternalLink></a>, Luos uses RS485 with a driver or one-wire communication for this physical layer ([see Electronic design](./electronics) page), but other communication ways are possible.
 
-Board examples and driver sources are available <a href="https://github.com/Luos-io/Examples/tree/master/Projects" target="_blank">on GitHub<IconExternalLink width="10"></IconExternalLink></a>. We encourage you to use them in the way you want.
+Board examples and driver sources are available <a href="https://github.com/Luos-io/luos_engine/tree/main/examples/projects" target="_blank" rel="external nofollow">on GitHub<IconExternalLink width="10"></IconExternalLink></a>. We encourage you to use them in the way you want.
 
-You can find the schematic of a Luos-ready board called L0 <a href="https://github.com/Luos-io/Examples/tree/master/Hardware/l0" target="_blank">on Github<IconExternalLink width="10"></IconExternalLink></a> for a quick hardware example.
+You can find the schematic of a Luos-ready board called L0 <a href="https://github.com/Luos-io/luos_engine/tree/main/examples/hardware/l0" target="_blank" rel="external nofollow">on Github<IconExternalLink width="10"></IconExternalLink></a> for a quick hardware example.

--- a/versioned_docs/version-2.2.0/hardware-consideration/test-your-configuration.mdx
+++ b/versioned_docs/version-2.2.0/hardware-consideration/test-your-configuration.mdx
@@ -1,7 +1,7 @@
 # Test your hardware configuration
 
 To adapt Luos to your board specificities, you need to configure it. This subject is covered in the [Luos configuration](./mcu).
-To validate your network hardware configuration, you can use a Luos tool called selftest available in the <a href="https://github.com/Luos-io/Luos" target="_blank">Luos Library<IconExternalLink width="10"></IconExternalLink></a>.
+To validate your network hardware configuration, you can use a Luos tool called selftest available in the <a href="https://github.com/Luos-io/luos_engine" target="_blank" rel="external nofollow">Luos Library<IconExternalLink width="10"></IconExternalLink></a>.
 
 ## Hardware test conditions
 

--- a/versioned_docs/version-2.2.0/luos-technology/basics/basics.mdx
+++ b/versioned_docs/version-2.2.0/luos-technology/basics/basics.mdx
@@ -19,7 +19,7 @@ Luos is here to back you up and keep your projects clean and smooth to develop, 
 
 ## Introduction to Luos
 
-**Luos is a simple and lightweight containerization platform dedicated to embedded systems enabling a <a href="https://en.wikipedia.org/wiki/Microservices" target="_blank">microservices<IconExternalLink width="10"></IconExternalLink></a> architecture for electronics.** It is a powerful modularity tool to simplify and link any hardware component or application code together as a <a href="https://en.wikipedia.org/wiki/Single_system_image" target="_blank">single system image<IconExternalLink width="10"></IconExternalLink></a>.
+**Luos is a simple and lightweight containerization platform dedicated to embedded systems enabling a <a href="https://en.wikipedia.org/wiki/Microservices" target="_blank" rel="external nofollow">microservices<IconExternalLink width="10"></IconExternalLink></a> architecture for electronics.** It is a powerful modularity tool to simplify and link any hardware component or application code together as a <a href="https://en.wikipedia.org/wiki/Single_system_image" target="_blank" rel="external nofollow">single system image<IconExternalLink width="10"></IconExternalLink></a>.
 
 This guide contains all the basic notions you will need to use, create and understand Luos technology.
 

--- a/versioned_docs/version-2.2.0/luos-technology/basics/concept.mdx
+++ b/versioned_docs/version-2.2.0/luos-technology/basics/concept.mdx
@@ -35,7 +35,7 @@ Services, much like their server-world counterparts, can be placed anywhere in y
 
 **Each service is hosted in a single node**, but you can have the same service duplicated multiple times in your product.
 
-For example, the Dynamixel example (available in the [GitHub example repository](https://github.com/Luos-io/Examples)) can dynamically create servomotors services depending on the number of Dynamixel motors linked to it. Any Dynamixel services are visible as independent servomotors similar to any other servomotor technology such as the stepper service example, or the controller motor service example. Then, you can use any of your Dynamixel from any other services or even from any computer, cloud program, or ecosystem such as ROS.
+For example, the Dynamixel example (available in the <a href="https://github.com/Luos-io/luos_engine/tree/main/examples" target ="_blank" rel="external nofollow">Luos engine example folder</a>) can dynamically create servomotors services depending on the number of Dynamixel motors linked to it. Any Dynamixel services are visible as independent servomotors similar to any other servomotor technology such as the stepper service example, or the controller motor service example. Then, you can use any of your Dynamixel from any other services or even from any computer, cloud program, or ecosystem such as ROS.
 
 There are two categories of services, [drivers](../services/service-api#drivers-guidelines) or [applications](../services/service-api#apps-guidelines).
 

--- a/versioned_docs/version-2.2.0/luos-technology/luos_tech.mdx
+++ b/versioned_docs/version-2.2.0/luos-technology/luos_tech.mdx
@@ -13,9 +13,7 @@ Luos is an open-source lightweight library that can be used on any MCU, leading 
 
 Most of the embedded developments are made from scratch. By using Luos, you will be able to capitalize on the development you, your company, or the Luos community already did. The re-usability of features encapsulated in Luos services will fasten the time your products reach the market and reassure the robustness and the universality of your applications.
 
-You can visit the <a href="https://www.reddit.com/r/Luos/" target ="_blank">Luos community on Reddit</a>.
-
-Need dedicated help with your project? <a href="https://www.luos.io/support" target ="_blank">Check out Luos' support packages</a>.
+Need dedicated help for your project? You can join the Luos community on <a href="https://discord.gg/luos" target ="_blank" rel="external nofollow">Discord</a> or <a href="https://www.reddit.com/r/Luos/" target ="_blank" rel="external nofollow">Reddit</a>.
 
 ## Good practices with Luos
 

--- a/versioned_docs/version-2.2.0/luos-technology/message/command.mdx
+++ b/versioned_docs/version-2.2.0/luos-technology/message/command.mdx
@@ -94,6 +94,6 @@ User's commands start at `LUOS_LAST_RESERVED_CMD`.
 | PARAMETERS | depends on the service. It can be: servo_parameters_t, imu_report_t, motor_mode_t |
 | ERROR_CMD  |                                                                                   |
 
-You can find the complete list of commands <a href="https://github.com/Luos-io/Luos/blob/master/inc/luos_list.h" target = "_blank">here<IconExternalLink width="10"></IconExternalLink></a>.
+You can find the complete list of commands <a href="https://github.com/Luos-io/luos_engine/blob/main/engine/core/inc/luos_list.h" target= "_blank" rel="external nofollow">here<IconExternalLink width="10"></IconExternalLink></a>.
 
 If you want to create new commands for your custom services, you can create and add your own starting at `LUOS_LAST_STD_CMD`. [See how](/tutorials).

--- a/versioned_docs/version-2.2.0/luos-technology/node/luos.mdx
+++ b/versioned_docs/version-2.2.0/luos-technology/node/luos.mdx
@@ -15,13 +15,13 @@ The node's embedded code hosts the Luos's embedded code and the node's various f
 
 Luos works as a code library running on nodes. To match the Luos library with your hardware, Luos offers a _Hardware Abstraction Layer_ for various devices in <Tooltip def={customFields.luoshal_def}>LuosHAL</Tooltip>.
 
-- <a href="https://github.com/Luos-io/LuosHAL" target="_blank">
+- <a href="https://github.com/Luos-io/LuosHAL" target="_blank" rel="external nofollow">
     LuosHAL
     <IconExternalLink width="10"></IconExternalLink>
   </a>
   : This repository provides a list of family devices covered to match the Luos library
   with your hardware.
-- <a href="https://github.com/Luos-io/Luos" target="_blank">
+- <a href="https://github.com/Luos-io/Luos" target="_blank" rel="external nofollow">
     Luos
     <IconExternalLink width="10"></IconExternalLink>
   </a>
@@ -94,11 +94,11 @@ You can use it to set all your custom configurations:
 |     MAX_MSG_NB     | 2\*MAX_SERVICE_NUMBER |                               Max number of messages that can be referenced by Luos.                               |
 |      NBR_PORT      |           2           | Number of PTP (port) on the node ( max 8). See [electronic design](../../hardware-consideration/electronics) page. |
 
-You will find the default configuration for Luos Library in the file <a href="https://github.com/Luos-io/Luos/tree/master/Robus/inc/config.h" target="_blank">config.h<IconExternalLink width="10"></IconExternalLink></a>,
+You will find the default configuration for Luos Library in the file <a href="https://github.com/Luos-io/luos_engine/blob/main/network/robus/inc/config.h" target="_blank" rel="external nofollow">config.h<IconExternalLink width="10"></IconExternalLink></a>,
 
 Check the Luos_hal_config.h of your MCU family to see parameters that can be changed to fit your design.
 
-> **Note:** [Every example](https://github.com/Luos-io/Examples) provided by Luos has a _node_config.h_ file that can be used as a base to fit your project's needs.
+> **Note:** <a href="https://github.com/Luos-io/luos_engine/tree/main/examples" target="_blank" rel="external nofollow">Every example</a>  provided by Luos has a _node_config.h_ file that can be used as a base to fit your project's needs.
 
 ## Luos Statistics
 

--- a/versioned_docs/version-2.2.0/luos-technology/services/profile.mdx
+++ b/versioned_docs/version-2.2.0/luos-technology/services/profile.mdx
@@ -13,7 +13,7 @@ The profile handles messaging to share your variables with other services. Moreo
 > **Example:** If you want to make a servo-motor service, you have to select the servo-motor profile for your service and use variables of the profile structure to set the rotor current position measurement, or to get the current motor target in your code.
 
 Profiles are convenient for making your code clean and straightforward, complying with your development into a standard API, or sharing your service type with the community.
-Luos provides some common profile models that you can use; feel free to contribute and to add your own to the standard profile bank with a pull request on <a href="https://github.com/Luos-io" target="_blank">Luos' GitHub page &#8599;</a>.
+Luos provides some common profile models that you can use; feel free to contribute and to add your own to the standard profile bank with a pull request on <a href="https://github.com/Luos-io" target="_blank" rel="external nofollow">Luos' GitHub page &#8599;</a>.
 
 ## How to use a profile in your service
 
@@ -64,4 +64,4 @@ void Button_Loop(void) {
 }
 ```
 
-You can notice that you don't send any Luos message to share the button state: if an application wants to access this information, the state profile will share it for you. You only have to update the button state value in your code. Supported profiles are available in this [repository](https://github.com/Luos-io/Luos/tree/master/Profiles).
+You can notice that you don't send any Luos message to share the button state: if an application wants to access this information, the state profile will share it for you. You only have to update the button state value in your code. Supported profiles are available in this <a href="https://github.com/Luos-io/luos_engine/tree/main/engine/profiles" target ="_blank" rel="external nofollow">repository</a>.

--- a/versioned_docs/version-2.3.0/api/api-json.mdx
+++ b/versioned_docs/version-2.3.0/api/api-json.mdx
@@ -13,7 +13,7 @@ import Image from '@site/src/components/Images.js';
   </a>
 </h1>
 
-The <a href="https://en.wikipedia.org/wiki/JSON" target="blank_">JSON formatted data</a> is common and widely used by many programming languages. Luos allows you to convert low-level Luos information into JSON objects, enabling conventional programming languages to interact with your device easily.
+The <a href="https://en.wikipedia.org/wiki/JSON" target="blank_" rel="external nofollow">JSON formatted data</a> is common and widely used by many programming languages. Luos allows you to convert low-level Luos information into JSON objects, enabling conventional programming languages to interact with your device easily.
 
 To do that, you must add a specific app service called a [gate](../tools/gate) on your device.
 
@@ -312,8 +312,8 @@ Parameters are defined by a 16-bit bitfield.
 
 |   Object   |               Definition               |                                                                         Structure                                                                         |            Service(s)            |
 | :--------: | :------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------------------------------------: | :------------------------------: |
-| parameters | enabling or disabling some measurement | [Link to structure (GitHub)](https://github.com/Luos-io/Examples/blob/master/Projects/l0/Controller_motor/lib/Controller_motor/controller_motor.h#L7-L31) | Stepper, Controller-motor, Servo |
-| parameters | enabling or disabling some measurement |             [Link to structure (GitHub)](https://github.com/Luos-io/Examples/blob/master/Projects/l0/Imu/lib/Imu/mpu_configuration.h#L37-L56)             |               Imu                |
+| parameters | enabling or disabling some measurement | [Link to structure (GitHub)](https://github.com/Luos-io/luos_engine/tree/main/examples/projects/l0/controller_motor) | Stepper, Controller-motor, Servo |
+| parameters | enabling or disabling some measurement |             [Link to structure (GitHub)](https://github.com/Luos-io/luos_engine/tree/main/examples/projects/l0/imu/lib/Imu)             |               Imu                |
 
 Other specific messages:
 

--- a/versioned_docs/version-2.3.0/hardware-consideration/electronics.mdx
+++ b/versioned_docs/version-2.3.0/hardware-consideration/electronics.mdx
@@ -15,7 +15,7 @@ To create and match with a default reference design, electronic boards must resp
 
 A Luos-friendly electronic board must contain _at least_ the following elements:
 
-- **1** <a href="https://en.wikipedia.org/wiki/Microcontroller" target="_blank">**MCU<IconExternalLink width="10"></IconExternalLink>**</a> (microcontroller unit): It hosts, as a node, the Luos firmware along with the different <Tooltip def={customFields.service_def} >services</Tooltip> (drivers and apps).
+- **1** <a href="https://en.wikipedia.org/wiki/Microcontroller" target="_blank" rel="external nofollow">**MCU<IconExternalLink width="10"></IconExternalLink>**</a> (microcontroller unit): It hosts, as a node, the Luos firmware along with the different <Tooltip def={customFields.service_def} >services</Tooltip> (drivers and apps).
 - **At least two connectors**: They allow to link boards together into a Luos network and link them as a daisy-chain or star mounting. Through PTP pins, nodes know if there is another node connected to the connector. This is used when the user wants to make a topology detection of the system.
 
 ## One-wire reference design
@@ -27,7 +27,7 @@ A Luos-friendly electronic board must contain _at least_ the following elements:
   />
 </div>
 
-Luos' One-wire official connector is <a href="https://octopart.com/df11-4dp-2ds%2852%29-hirose-261749" target="_blank">_DF11-4DP-2DS<IconExternalLink width="10"></IconExternalLink>_</a>.
+Luos' One-wire official connector is <a href="https://octopart.com/df11-4dp-2ds%2852%29-hirose-261749" target="_blank" rel="external nofollow">_DF11-4DP-2DS<IconExternalLink width="10"></IconExternalLink>_</a>.
 
 ## RS485 reference design
 
@@ -38,6 +38,6 @@ Luos' One-wire official connector is <a href="https://octopart.com/df11-4dp-2ds%
   />
 </div>
 
-Luos' RS485 official connector is <a href="https://octopart.com/df11-8dp-2ds%2824%29-hirose-39521447" target="_blank">_DF11-8DP-2DS<IconExternalLink width="10"></IconExternalLink>_</a>.
+Luos' RS485 official connector is <a href="https://octopart.com/df11-8dp-2ds%2824%29-hirose-39521447" target="_blank" rel="external nofollow">_DF11-8DP-2DS<IconExternalLink width="10"></IconExternalLink>_</a>.
 
-See the default pinout configuration in <a href="https://github.com/Luos-io/LuosHAL" target="_blank">_luos_hal_config.h<IconExternalLink width="10"></IconExternalLink>_</a> file for chosen the MCU family.
+See the default pinout configuration in <a href="https://github.com/Luos-io/LuosHAL" target="_blank" rel="external nofollow">_luos_hal_config.h<IconExternalLink width="10"></IconExternalLink>_</a> file for chosen the MCU family.

--- a/versioned_docs/version-2.3.0/hardware-consideration/hardware-consideration.mdx
+++ b/versioned_docs/version-2.3.0/hardware-consideration/hardware-consideration.mdx
@@ -6,8 +6,8 @@ import IconExternalLink from "@theme/IconExternalLink";
 
 # Hardware consideration
 
-When creating a Luos network, if you have a product with several nodes, it is mandatory to configure your MCU, to create the physical layer. In <a href="https://github.com/Luos-io/Examples/" target="_blank">Luos's examples on GitHub<IconExternalLink width="10"></IconExternalLink></a>, Luos uses RS485 with a driver or one-wire communication for this physical layer ([see Electronic design](./electronics) page), but other communication ways are possible.
+When creating a Luos network, if you have a product with several nodes, it is mandatory to configure your MCU, to create the physical layer. In <a href="https://github.com/Luos-io/luos_engine/tree/main/examples" target="_blank" rel="external nofollow">Luos's examples on GitHub<IconExternalLink width="10"></IconExternalLink></a>, Luos uses RS485 with a driver or one-wire communication for this physical layer ([see Electronic design](./electronics) page), but other communication ways are possible.
 
-Board examples and driver sources are available <a href="https://github.com/Luos-io/Examples/tree/master/Projects" target="_blank">on GitHub<IconExternalLink width="10"></IconExternalLink></a>. We encourage you to use them in the way you want.
+Board examples and driver sources are available <a href="https://github.com/Luos-io/luos_engine/tree/main/examples/projects" target="_blank" rel="external nofollow">on GitHub<IconExternalLink width="10"></IconExternalLink></a>. We encourage you to use them in the way you want.
 
-You can find the schematic of a Luos-ready board called L0 <a href="https://github.com/Luos-io/Examples/tree/master/Hardware/l0" target="_blank">on Github<IconExternalLink width="10"></IconExternalLink></a> for a quick hardware example.
+You can find the schematic of a Luos-ready board called L0 <a href="https://github.com/Luos-io/luos_engine/tree/main/examples/hardware/l0" target="_blank" rel="external nofollow">on Github<IconExternalLink width="10"></IconExternalLink></a> for a quick hardware example.

--- a/versioned_docs/version-2.3.0/hardware-consideration/test-your-configuration.mdx
+++ b/versioned_docs/version-2.3.0/hardware-consideration/test-your-configuration.mdx
@@ -1,7 +1,7 @@
 # Test your hardware configuration
 
 To adapt Luos to your board specificities, you need to configure it. This subject is covered in the [Luos configuration](./mcu).
-To validate your network hardware configuration, you can use a Luos tool called selftest available in the <a href="https://github.com/Luos-io/Luos" target="_blank">Luos Library<IconExternalLink width="10"></IconExternalLink></a>.
+To validate your network hardware configuration, you can use a Luos tool called selftest available in the <a href="https://github.com/Luos-io/luos_engine" target="_blank" rel="external nofollow">Luos Library<IconExternalLink width="10"></IconExternalLink></a>.
 
 ## Hardware test conditions
 

--- a/versioned_docs/version-2.3.0/luos-technology/basics/basics.mdx
+++ b/versioned_docs/version-2.3.0/luos-technology/basics/basics.mdx
@@ -19,7 +19,7 @@ Luos is here to back you up and keep your projects clean and smooth to develop, 
 
 ## Introduction to Luos
 
-**Luos is a simple and lightweight containerization platform dedicated to embedded systems enabling a <a href="https://en.wikipedia.org/wiki/Microservices" target="_blank">microservices<IconExternalLink width="10"></IconExternalLink></a> architecture for electronics.** It is a powerful modularity tool to simplify and link any hardware component or application code together as a <a href="https://en.wikipedia.org/wiki/Single_system_image" target="_blank">single system image<IconExternalLink width="10"></IconExternalLink></a>.
+**Luos is a simple and lightweight containerization platform dedicated to embedded systems enabling a <a href="https://en.wikipedia.org/wiki/Microservices" target="_blank" rel="external nofollow">microservices<IconExternalLink width="10"></IconExternalLink></a> architecture for electronics.** It is a powerful modularity tool to simplify and link any hardware component or application code together as a <a href="https://en.wikipedia.org/wiki/Single_system_image" target="_blank" rel="external nofollow">single system image<IconExternalLink width="10"></IconExternalLink></a>.
 
 This guide contains all the basic notions you will need to use, create and understand Luos technology.
 

--- a/versioned_docs/version-2.3.0/luos-technology/basics/concept.mdx
+++ b/versioned_docs/version-2.3.0/luos-technology/basics/concept.mdx
@@ -35,7 +35,7 @@ Services, much like their server-world counterparts, can be placed anywhere in y
 
 **Each service is hosted in a single node**, but you can have the same service duplicated multiple times in your product.
 
-For example, the Dynamixel example (available in the [GitHub example repository](https://github.com/Luos-io/Examples)) can dynamically create servomotors services depending on the number of Dynamixel motors linked to it. Any Dynamixel services are visible as independent servomotors similar to any other servomotor technology such as the stepper service example, or the controller motor service example. Then, you can use any of your Dynamixel from any other services or even from any computer, cloud program, or ecosystem such as ROS.
+For example, the Dynamixel example (available in the <a href="https://github.com/Luos-io/luos_engine/tree/main/examples" target ="_blank" rel="external nofollow">Luos engine example folder</a>) can dynamically create servomotors services depending on the number of Dynamixel motors linked to it. Any Dynamixel services are visible as independent servomotors similar to any other servomotor technology such as the stepper service example, or the controller motor service example. Then, you can use any of your Dynamixel from any other services or even from any computer, cloud program, or ecosystem such as ROS.
 
 There are two categories of services, [drivers](../services/service-api#drivers-guidelines) or [applications](../services/service-api#apps-guidelines).
 

--- a/versioned_docs/version-2.3.0/luos-technology/luos_tech.mdx
+++ b/versioned_docs/version-2.3.0/luos-technology/luos_tech.mdx
@@ -13,9 +13,7 @@ Luos is an open-source lightweight library that can be used on any MCU, leading 
 
 Most of the embedded developments are made from scratch. By using Luos, you will be able to capitalize on the development you, your company, or the Luos community already did. The re-usability of features encapsulated in Luos services will fasten the time your products reach the market and reassure the robustness and the universality of your applications.
 
-You can visit the <a href="https://www.reddit.com/r/Luos/" target ="_blank">Luos community on Reddit</a>.
-
-Need dedicated help with your project? <a href="https://www.luos.io/support" target ="_blank">Check out Luos' support packages</a>.
+Need dedicated help for your project? You can join the Luos community on <a href="https://discord.gg/luos" target ="_blank" rel="external nofollow">Discord</a> or <a href="https://www.reddit.com/r/Luos/" target ="_blank" rel="external nofollow">Reddit</a>.
 
 ## Good practices with Luos
 

--- a/versioned_docs/version-2.3.0/luos-technology/message/command.mdx
+++ b/versioned_docs/version-2.3.0/luos-technology/message/command.mdx
@@ -94,6 +94,6 @@ User's commands start at `LUOS_LAST_RESERVED_CMD`.
 | PARAMETERS | depends on the service. It can be: servo_parameters_t, imu_report_t, motor_mode_t |
 | ERROR_CMD  |                                                                                   |
 
-You can find the complete list of commands <a href="https://github.com/Luos-io/Luos/blob/master/inc/luos_list.h" target = "_blank">here<IconExternalLink width="10"></IconExternalLink></a>.
+You can find the complete list of commands <a href="https://github.com/Luos-io/luos_engine/blob/main/engine/core/inc/luos_list.h" target= "_blank" rel="external nofollow">here<IconExternalLink width="10"></IconExternalLink></a>.
 
 If you want to create new commands for your custom services, you can create and add your own starting at `LUOS_LAST_STD_CMD`. [See how](/tutorials).

--- a/versioned_docs/version-2.3.0/luos-technology/node/luos.mdx
+++ b/versioned_docs/version-2.3.0/luos-technology/node/luos.mdx
@@ -15,13 +15,13 @@ The node's embedded code hosts the Luos's embedded code and the node's various f
 
 Luos works as a code library running on nodes. To match the Luos library with your hardware, Luos offers a _Hardware Abstraction Layer_ for various devices in <Tooltip def={customFields.luoshal_def}>LuosHAL</Tooltip>.
 
-- <a href="https://github.com/Luos-io/LuosHAL" target="_blank">
+- <a href="https://github.com/Luos-io/LuosHAL" target="_blank" rel="external nofollow">
     LuosHAL
     <IconExternalLink width="10"></IconExternalLink>
   </a>
   : This repository provides a list of family devices covered to match the Luos library
   with your hardware.
-- <a href="https://github.com/Luos-io/Luos" target="_blank">
+- <a href="https://github.com/Luos-io/Luos" target="_blank" rel="external nofollow">
     Luos
     <IconExternalLink width="10"></IconExternalLink>
   </a>
@@ -94,11 +94,11 @@ You can use it to set all your custom configurations:
 |     MAX_MSG_NB     | 2\*MAX_SERVICE_NUMBER |                               Max number of messages that can be referenced by Luos.                               |
 |      NBR_PORT      |           2           | Number of PTP (port) on the node ( max 8). See [electronic design](../../hardware-consideration/electronics) page. |
 
-You will find the default configuration for Luos Library in the file <a href="https://github.com/Luos-io/Luos/tree/master/Robus/inc/config.h" target="_blank">config.h<IconExternalLink width="10"></IconExternalLink></a>,
+You will find the default configuration for Luos Library in the file <a href="https://github.com/Luos-io/luos_engine/blob/main/network/robus/inc/config.h" target="_blank" rel="external nofollow">config.h<IconExternalLink width="10"></IconExternalLink></a>,
 
 Check the Luos_hal_config.h of your MCU family to see parameters that can be changed to fit your design.
 
-> **Note:** [Every example](https://github.com/Luos-io/Examples) provided by Luos has a _node_config.h_ file that can be used as a base to fit your project's needs.
+> **Note:** <a href="https://github.com/Luos-io/luos_engine/tree/main/examples" target="_blank" rel="external nofollow">Every example</a> provided by Luos has a _node_config.h_ file that can be used as a base to fit your project's needs.
 
 ## Luos Statistics
 

--- a/versioned_docs/version-2.3.0/luos-technology/services/profile.mdx
+++ b/versioned_docs/version-2.3.0/luos-technology/services/profile.mdx
@@ -13,7 +13,7 @@ The profile handles messaging to share your variables with other services. Moreo
 > **Example:** If you want to make a servo-motor service, you have to select the servo-motor profile for your service and use variables of the profile structure to set the rotor current position measurement, or to get the current motor target in your code.
 
 Profiles are convenient for making your code clean and straightforward, complying with your development into a standard API, or sharing your service type with the community.
-Luos provides some common profile models that you can use; feel free to contribute and to add your own to the standard profile bank with a pull request on <a href="https://github.com/Luos-io" target="_blank">Luos' GitHub page &#8599;</a>.
+Luos provides some common profile models that you can use; feel free to contribute and to add your own to the standard profile bank with a pull request on <a href="https://github.com/Luos-io" target="_blank" rel="external nofollow">Luos' GitHub page &#8599;</a>.
 
 ## How to use a profile in your service
 
@@ -64,4 +64,4 @@ void Button_Loop(void) {
 }
 ```
 
-You can notice that you don't send any Luos message to share the button state: if an application wants to access this information, the state profile will share it for you. You only have to update the button state value in your code. Supported profiles are available in this [repository](https://github.com/Luos-io/Luos/tree/master/Profiles).
+You can notice that you don't send any Luos message to share the button state: if an application wants to access this information, the state profile will share it for you. You only have to update the button state value in your code. Supported profiles are available in this <a href="https://github.com/Luos-io/luos_engine/tree/main/engine/profiles" target ="_blank" rel="external nofollow">repository</a>.

--- a/versioned_docs/version-2.4.0/api/api-json.mdx
+++ b/versioned_docs/version-2.4.0/api/api-json.mdx
@@ -13,7 +13,7 @@ import Image from '@site/src/components/Images.js';
   </a>
 </h1>
 
-The <a href="https://en.wikipedia.org/wiki/JSON" target="blank_">JSON formatted data</a> is common and widely used by many programming languages. Gate services allow you to convert Luos engine information into JSON objects, enabling conventional programming languages to interact with your device easily.
+The <a href="https://en.wikipedia.org/wiki/JSON" target="blank_" rel="external nofollow">JSON formatted data</a> is common and widely used by many programming languages. Gate services allow you to convert Luos engine information into JSON objects, enabling conventional programming languages to interact with your device easily.
 
 To do that, you must add a specific app service called a [gate](../tools/gate) on your device.
 
@@ -312,8 +312,8 @@ Parameters are defined by a 16-bit bitfield.
 
 |   Object   |               Definition               |                                                                         Structure                                                                         |            Service(s)            |
 | :--------: | :------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------------------------------------: | :------------------------------: |
-| parameters | enabling or disabling some measurement | [Link to structure (GitHub)](https://github.com/Luos-io/luos_engine/tree/main/Examples/Projects/l0/Controller_motor/lib/Controller_motor/controller_motor.h#L7-L31) | Stepper, Controller-motor, Servo |
-| parameters | enabling or disabling some measurement |             [Link to structure (GitHub)](https://github.com/Luos-io/luos_engine/tree/main/Examples/Projects/l0/Imu/lib/Imu/mpu_configuration.h#L37-L56)             |               Imu                |
+| parameters | enabling or disabling some measurement | [Link to structure (GitHub)](https://github.com/Luos-io/luos_engine/tree/main/examples/projects/l0/controller_motor) | Stepper, Controller-motor, Servo |
+| parameters | enabling or disabling some measurement |             [Link to structure (GitHub)](https://github.com/Luos-io/luos_engine/tree/main/examples/projects/l0/imu/lib/Imu)             |               Imu                |
 
 Other specific messages:
 

--- a/versioned_docs/version-2.4.0/hardware-consideration/electronics.mdx
+++ b/versioned_docs/version-2.4.0/hardware-consideration/electronics.mdx
@@ -29,7 +29,7 @@ A Luos-friendly electronic board must contain _at least_ the following elements:
   />
 </div>
 
-Robus' One-wire official connector is <a href="https://octopart.com/df11-4dp-2ds%2852%29-hirose-261749" target="_blank">_DF11-4DP-2DS<IconExternalLink width="10"></IconExternalLink>_</a>.
+Robus' One-wire official connector is <a href="https://octopart.com/df11-4dp-2ds%2852%29-hirose-261749" target="_blank" rel="external nofollow">_DF11-4DP-2DS<IconExternalLink width="10"></IconExternalLink>_</a>.
 
 ## RS485 reference design
 
@@ -40,6 +40,6 @@ Robus' One-wire official connector is <a href="https://octopart.com/df11-4dp-2ds
   />
 </div>
 
-Robus' RS485 official connector is <a href="https://octopart.com/df11-8dp-2ds%2824%29-hirose-39521447" target="_blank">_DF11-8DP-2DS<IconExternalLink width="10"></IconExternalLink>_</a>.
+Robus' RS485 official connector is <a href="https://octopart.com/df11-8dp-2ds%2824%29-hirose-39521447" target="_blank" rel="external nofollow">_DF11-8DP-2DS<IconExternalLink width="10"></IconExternalLink>_</a>.
 
-See the default pinout configuration in the <a href="https://github.com/Luos-io/luos_engine/tree/main/Network/Robus/HAL" target="_blank">_luos_hal_config.h<IconExternalLink width="10"></IconExternalLink>_</a> file, situated in the folder associated to the chosen MCU family.
+See the default pinout configuration in the <a href="https://github.com/Luos-io/luos_engine/tree/main/Network/Robus/HAL" target="_blank" rel="external nofollow">_luos_hal_config.h<IconExternalLink width="10"></IconExternalLink>_</a> file, situated in the folder associated to the chosen MCU family.

--- a/versioned_docs/version-2.4.0/hardware-consideration/index.mdx
+++ b/versioned_docs/version-2.4.0/hardware-consideration/index.mdx
@@ -8,8 +8,8 @@ import IconExternalLink from "@theme/IconExternalLink";
 
 Luos engine needs to acces your hardware to properly work.
 
-When creating a Luos network, if you have a product with several nodes, it is mandatory to configure your MCU to create the network's physical layer. In <a href="https://github.com/Luos-io/luos_engine/tree/main/Examples/" target="_blank">Luos's examples on GitHub<IconExternalLink width="10"></IconExternalLink></a>, we use the Robus network interface with RS485 or one-wire communication (for this physical layer [see Electronic design](./electronics) page), but other networks can be used as well.
+When creating a Luos network, if you have a product with several nodes, it is mandatory to configure your MCU to create the network's physical layer. In <a href="https://github.com/Luos-io/luos_engine/tree/main/examples" target="_blank" rel="external nofollow">Luos's examples on GitHub<IconExternalLink width="10"></IconExternalLink></a>, we use the Robus network interface with RS485 or one-wire communication (for this physical layer [see Electronic design](./electronics) page), but other networks can be used as well.
 
-Board examples and driver sources are available <a href="https://github.com/Luos-io/luos_engine/tree/main/Examples/tree/master/Projects" target="_blank">on GitHub<IconExternalLink width="10"></IconExternalLink></a>. We encourage you to use them as a reference, the way you want.
+Board examples and driver sources are available <a href="https://github.com/Luos-io/luos_engine/tree/main/examples/projects" target="_blank" rel="external nofollow">on GitHub<IconExternalLink width="10"></IconExternalLink></a>. We encourage you to use them as a reference, the way you want.
 
-You can find the schematics of a Luos-ready board called L0 <a href="https://github.com/Luos-io/luos_engine/tree/main/Examples/tree/master/Hardware/l0" target="_blank">on Github<IconExternalLink width="10"></IconExternalLink></a> for a quick hardware example.
+You can find the schematics of a Luos-ready board called L0 <a href="https://github.com/Luos-io/luos_engine/tree/main/examples/hardware/l0" target="_blank" rel="external nofollow">on Github<IconExternalLink width="10"></IconExternalLink></a> for a quick hardware example.

--- a/versioned_docs/version-2.4.0/hardware-consideration/mcu.mdx
+++ b/versioned_docs/version-2.4.0/hardware-consideration/mcu.mdx
@@ -14,7 +14,7 @@ Luos engine can manage any type of microcontrollers as long as they have a HAL. 
 - by mail <a href="mailto:hello@luos.io">hello&#x40;luos.io</a>
 - on <a href="https://github.com/Luos-io/luos_engine/issues/new?assignees=nicolas-rabault&labels=porting&template=porting-request.md&title=%5BMCU+PORTING%5D+" target="_blank">GitHub</a>
 
-Check the list of MCU families Luos engine cover:<a href="https://github.com/Luos-io/luos_engine/tree/main/Engine/HAL" target="_blank">Hardware Abstraction Layers for MCU families</a>,
+Check the list of MCU families Luos engine cover:<a href="https://github.com/Luos-io/luos_engine/tree/main/engine/HAL" target="_blank">Hardware Abstraction Layers for MCU families</a>,
 
 > Depending on what network you have, you may also configure the specific HAL of your network. By default, Luos engine uses the Robus network layer with <a href="https://github.com/Luos-io/luos_engine/tree/main/Network/Robus/HAL" target="_blank">Robus HAL</a>.
 

--- a/versioned_docs/version-2.4.0/hardware-consideration/test-your-configuration.mdx
+++ b/versioned_docs/version-2.4.0/hardware-consideration/test-your-configuration.mdx
@@ -1,7 +1,7 @@
 # Test your Robus configuration
 
 To adapt Luos engine to your board specificities, you need to configure it. This subject is covered in the [Luos engine configuration](./mcu).
-To validate your Robus network's hardware configuration, you can use a Robus tool called _selftest_ available in the <a href="https://github.com/Luos-io/luos_engine/tree/main/Network/Robus/SelfTest" target="_blank">Luos engine's 'library<IconExternalLink width="10"></IconExternalLink></a>.
+To validate your Robus network's hardware configuration, you can use a Robus tool called _selftest_ available in the <a href="https://github.com/Luos-io/luos_engine/tree/main/network/robus/selftest" target="_blank" rel="external nofollow">Luos engine's 'library<IconExternalLink width="10"></IconExternalLink></a>.
 
 ## Hardware test conditions
 

--- a/versioned_docs/version-2.4.0/luos-technology/basics/concept.mdx
+++ b/versioned_docs/version-2.4.0/luos-technology/basics/concept.mdx
@@ -18,7 +18,7 @@ Technically, this engine is an embedded lightwheight and realtime C code library
 As Luos engine is not an operating system, you can use it with or without any operating system.
 :::
 
-Luos engine is open-source under _Apache 2.0_ license and available [on GitHub](https://github.com/Luos-io/luos_engine/tree/main).
+Luos engine is open-source under _Apache 2.0_ license and available <a href="https://github.com/Luos-io/luos_engine/tree/main" target ="_blank" rel="external nofollow">on GitHub</a>.
 
 ## What is a Node?
 
@@ -47,7 +47,7 @@ Services, much like their server-world counterparts, can be placed anywhere in y
 
 **Each service is hosted in a single node**, but you can have the same service duplicated multiple times in your product.
 
-For instance, the Dynamixel example (available in the [Luos engine example folder](https://github.com/Luos-io/luos_engine/tree/main/Examples)) can dynamically create servomotors services depending on the number of Dynamixel motors linked to it. Any Dynamixel service is visible as an independent servomotor similar to any other servomotor technology, such as the stepper service example or the controller motor service example. Then, you can use any of your Dynamixels from any other services or even from any computer, cloud program, or ecosystem such as ROS.
+For instance, the Dynamixel example (available in the <a href="https://github.com/Luos-io/luos_engine/tree/main/examples" target ="_blank" rel="external nofollow">Luos engine example folder</a>) can dynamically create servomotors services depending on the number of Dynamixel motors linked to it. Any Dynamixel service is visible as an independent servomotor similar to any other servomotor technology, such as the stepper service example or the controller motor service example. Then, you can use any of your Dynamixels from any other services or even from any computer, cloud program, or ecosystem such as ROS.
 
 There are two categories of services, [drivers](../services/service-api#drivers-guidelines) or [applications](../services/service-api#apps-guidelines).
 

--- a/versioned_docs/version-2.4.0/luos-technology/basics/index.mdx
+++ b/versioned_docs/version-2.4.0/luos-technology/basics/index.mdx
@@ -19,7 +19,7 @@ Luos is here to back you up and keep your projects clean and smooth to develop, 
 
 ## Introduction to Luos
 
-**Luos is a simple and lightweight containerization platform dedicated to embedded systems enabling a <a href="https://en.wikipedia.org/wiki/Microservices" target="_blank">microservices<IconExternalLink width="10"></IconExternalLink></a> architecture for electronics.** It is a powerful modularity tool to simplify and link any hardware component or application code together as a <a href="https://en.wikipedia.org/wiki/Single_system_image" target="_blank">single system image<IconExternalLink width="10"></IconExternalLink></a>.
+**Luos is a simple and lightweight containerization platform dedicated to embedded systems enabling a <a href="https://en.wikipedia.org/wiki/Microservices" target="_blank" rel="external nofollow">microservices<IconExternalLink width="10"></IconExternalLink></a> architecture for electronics.** It is a powerful modularity tool to simplify and link any hardware component or application code together as a <a href="https://en.wikipedia.org/wiki/Single_system_image" target="_blank" rel="external nofollow">single system image<IconExternalLink width="10"></IconExternalLink></a>.
 
 This guide contains all the basic notions you will need to use, create and understand Luos technology.
 

--- a/versioned_docs/version-2.4.0/luos-technology/index.mdx
+++ b/versioned_docs/version-2.4.0/luos-technology/index.mdx
@@ -13,9 +13,7 @@ Luos engine is an open-source lightweight library that can be used on any MCU, l
 
 Most of the embedded developments are made from scratch. By using Luos engine, you will be able to capitalize on the development you, your company, or the Luos community already did. The re-usability of features encapsulated in Luos engine services will fasten the time your products reach the market and reassure the robustness and the universality of your applications.
 
-You can visit the Luos community on <a href="https://www.reddit.com/r/Luos/" target ="_blank">Reddit</a> or <a href="http://bit.ly/JoinLuosDiscord" target ="_blank">Discord</a>.
-
-Need dedicated help for your project? <a href="https://www.luos.io/support" target ="_blank">Check out Luos' support packages</a>.
+Need dedicated help for your project? You can join the Luos community on <a href="https://discord.gg/luos" target ="_blank" rel="external nofollow">Discord</a> or <a href="https://www.reddit.com/r/Luos/" target ="_blank" rel="external nofollow">Reddit</a>.
 
 ## Good practices with Luos
 

--- a/versioned_docs/version-2.4.0/luos-technology/message/command.mdx
+++ b/versioned_docs/version-2.4.0/luos-technology/message/command.mdx
@@ -94,6 +94,6 @@ User's commands start at `LUOS_LAST_RESERVED_CMD`.
 | PARAMETERS | depends on the service. It can be: servo_parameters_t, imu_report_t, motor_mode_t |
 | ERROR_CMD  |                                                                                   |
 
-You can find the complete list of commands <a href="https://github.com/Luos-io/luos_engine/blob/main/Engine/Core/inc/luos_list.h" target = "_blank">here<IconExternalLink width="10"></IconExternalLink></a>.
+You can find the complete list of commands <a href="https://github.com/Luos-io/luos_engine/blob/main/engine/core/inc/luos_list.h" target= "_blank" rel="external nofollow">here<IconExternalLink width="10"></IconExternalLink></a>.
 
 If you want to create new commands for your custom services, you can create and add your own starting at `LUOS_LAST_STD_CMD`. [See how](/tutorials).

--- a/versioned_docs/version-2.4.0/luos-technology/node/luos.mdx
+++ b/versioned_docs/version-2.4.0/luos-technology/node/luos.mdx
@@ -18,7 +18,7 @@ Luos engine works as a code library running on nodes. It can use several network
 To match the Luos engine's library with your hardware, it offers an _Hardware Abstraction Layer_ for various devices in the <Tooltip def={customFields.luoshal_def}>Luos engine's HAL folder</Tooltip>.
 There is also specific _Hardware Abstraction Layers_ for each network layer.
 
-- <a href="https://github.com/Luos-io/luos_engine" target="_blank">
+- <a href="https://github.com/Luos-io/luos_engine" target="_blank" rel="external nofollow">
     Luos engine
     <IconExternalLink width="10"></IconExternalLink>
   </a>
@@ -95,11 +95,11 @@ You can use it to set all your custom configurations:
 |     MAX_MSG_NB     | 2\*MAX_SERVICE_NUMBER |                               Max number of messages that can be referenced by Luos.                               |
 |      NBR_PORT      |           2           | Number of PTP (port) on the node ( max 8). See [electronic design](../../hardware-consideration/electronics) page. |
 
-You will find the default configuration for Luos engine in the file <a href="https://github.com/Luos-io/luos_engine/blob/main/Network/Robus/inc/config.h" target="_blank">_config.h<IconExternalLink width="10"></IconExternalLink>_</a>.
+You will find the default configuration for Luos engine in the file <a href="https://github.com/Luos-io/luos_engine/blob/main/network/robus/inc/config.h" target="_blank" rel="external nofollow">_config.h<IconExternalLink width="10"></IconExternalLink>_</a>.
 
 Check the _Luos_hal_config.h_ and your _Network_hal_config.h_ of your MCU family to see parameters that can be changed to fit your design.
 
-> **Note:** [Every example](https://github.com/Luos-io/luos_engine/tree/main/Examples) provided by Luos has a _node_config.h_ file that can be used as a base to fit your project's needs.
+> **Note:** <a href="https://github.com/Luos-io/luos_engine/tree/main/examples" target="_blank" rel="external nofollow">Every example</a>provided by Luos has a _node_config.h_ file that can be used as a base to fit your project's needs.
 
 ## Luos Statistics
 

--- a/versioned_docs/version-2.4.0/luos-technology/services/profile.mdx
+++ b/versioned_docs/version-2.4.0/luos-technology/services/profile.mdx
@@ -15,7 +15,7 @@ The profile handles messaging to share your variables with other services. Moreo
 :::
 
 Profiles are convenient for making your code clean and straightforward, complying with your development into a standard API, or sharing your service's type with the community.
-Luos engine provides some common profile models that you can use; feel free to contribute and to add your own to the standard profile bank with a pull request on <a href="https://github.com/Luos-io" target="_blank">Luos engine GitHub page &#8599;</a>.
+Luos engine provides some common profile models that you can use; feel free to contribute and to add your own to the standard profile bank with a pull request on <a href="https://github.com/Luos-io" target="_blank" rel="external nofollow">Luos engine GitHub page &#8599;</a>.
 
 ## How to use a profile in your service
 
@@ -66,4 +66,4 @@ void Button_Loop(void) {
 }
 ```
 
-You can notice that you did not send any Luos message to share the button's state: if an application wants to access this information, the state profile will share it for you. You only have to update the button's state value in your code. Supported profiles are available in this [repository](https://github.com/Luos-io/luos_engine/tree/main/Engine/Profiles).
+You can notice that you did not send any Luos message to share the button's state: if an application wants to access this information, the state profile will share it for you. You only have to update the button's state value in your code. Supported profiles are available in this <a href="https://github.com/Luos-io/luos_engine/tree/main/engine/profiles" target ="_blank" rel="external nofollow">repository</a>.


### PR DESCRIPTION
⚠ PLEASE DO NOT DELETE THE TEXT BELOW ⚠

## Pull request's description

*Add here a description of the modifications you made.*

## Checklist before merging (please do not edit)
You must review you work before to submit the review to others.

### Self-review of your content
Remember the content must be readable and understandable by someone else than yourself.
- [ ] From a technical point of view.
- [ ] From a grammatical point of view (spelling mistakes, typos, clarity, etc.), and following the guidelines at the bottom.

### External reviews of your content
- [x] You requested a technical review.
- [ ] You requested a grammatical review.
- [ ] You validated with @K0rdan or @alexgeron-Luos that it is safe to merge.

### Some guidelines to keep in mind
- Colons (:), semi-colons (;), exclamation (!), and interrogation points (?) are not preceded by a space (like full stops and commas). E.g.: Colons!
- File names and/or address are put in *italic*. E.g.: The file _main.c_.
- Functions, variables, or more generally short codes are put between grave accents. E.g.: To obtain `code()`, type \`code()\`.
- Long codes are put into blocks of code with three grave accent on each side, and the language's name:<br />
\`\`\`c<br />
// Some C language <br />
\`\`\`<br />

- "Luos engine" has a upper case on the **L** for "Luos" and lower case on the **e** for "engine".
- We call it "Luos engine" as a proper name, and ***not*** "the Luos engine".
- Following that fashion, anything that's owned by "Luos engine" implies that we must use `'s` as the standard English rule to show the possessive case, e.g. "Luos engine's API".
- The names pipe, gate, inspector, sniffer, app or application, driver, etc. have a lower case and can be refereed with the determiner `the`. E.g.: The inspector.
