### PR TITLE
Feat/bootloader update

### DIFF
--- a/docs/tools/boot.mdx
+++ b/docs/tools/boot.mdx
@@ -147,6 +147,13 @@ pyluos-bootloader flash COM3 -b firmware_new.bin
 No matter what problem you encounter during the loading process, you have to power-off / power-on your network to see all the nodes running in bootloader mode. Once you get there, you have to use `pyluos-bootloader detect` / `flash` tools to load applications and make it work fine.
 :::
 
+### ST-Link connected gate
+
+If for the communication of the gate with your computer, you are using the ST-Link protocol, and the flashing process is blocked in the last step of flashing with no specific reason, then you may have come through a specific problem caused by the ST-Link driver, with a specific size of binary, when flashing with a Luos bootloader.
+:::tip
+To reasure yourself that this is the case, you can try changing the size of your binary by changing some bytes of your code, or you can use an other way to connect your gate, like for example FTDI, and retry to flash your application with Luos bootloader. 
+:::
+
 ## How to add the bootloader feature in your project
 
 ### CLI tool
@@ -177,7 +184,7 @@ Examples are available for several IDEs: L4 / F4 / G4 / F0 uses platformIO, and 
 #### If Luos engine does not support your target yet
 
 If no project exists for your MCU, you will have to create your bootloader project.
-First of all, you have to **enable the bootloader feature** in Luos engine. To do so, you have to add the `-D BOOTLOADER_CONFIG` parameter when you invoke your compiler. Then you have to run the library in your `main()` function as you would do for any other project:
+First of all, you have to **enable the bootloader feature** in Luos engine. To do so, you have to add the `-D BOOTLOADER` parameter when you invoke your compiler. Then you have to run the library in your `main()` function as you would do for any other project:
 
 ```C
 #include "luos_engine.h"
@@ -209,6 +216,21 @@ This figure shows a third section called **shared_flash**, which exchanges infor
   <Image src="/img/linker_bootloader.png" />
 </div>
 
+### Flash memory remapping
+
+In each different Luos compatible board, we propose a default configuration of the flash memory. That is to say, by default, the bootloader's code is placed in the beginning of flash, then we place the Shared memory, and at the end we position the applications code, like explained in the above image. However, we give you the possibility to configure the flash as you want, by exposing some macros that you can redefine in the node_config.h file of your bootloader or application. These are:
+
+
+  | Define                | Description                                                                                |
+  |:---------------------:|:-------------------------------------------------------------------------------------------:
+  | BOOT_START_ADDRESS    | Start address of Bootloader in flash                                                       |
+  | SHARED_MEMORY_ADDRESS | Start address of shared memory to save boot flag                                           |
+  | SHARED_MEMORY_SECTOR  | Start sector of shared memory (in case of boards with flash in sectors)                    |
+  | APP_START_ADDRESS     | Start address of application with bootloader                                               |
+  | APP_END_ADDRESS       | End address of application with bootloader                                                 |
+  | APP_START_SECTOR      | Start sector of application with bootloader (in case of boards with flash in sectors)      |
+  | APP_END_SECTOR        | last sector of application with bootloader (in case of boards with flash in sectors)       |
+
 ### Applications
 
 As for the bootloader, you have to modify your linker file in the application if you want to make it compatible with this feature. Now that we defined the memory layout, the modification is straightforward:
@@ -217,58 +239,8 @@ As for the bootloader, you have to modify your linker file in the application if
   <Image src="/img/linker_app.png" />
 </div>
 
-You also have to set up the `VTOR` register to the APP_ADDRESS. This feature exists in most modern ARM CPUs and allows to jump to applications saved at any address in flash. On STM32L4, this register is set in `SystemInit()` function:
-
-```c
-#define VECT_TAB_OFFSET  0xC800
-
-void SystemInit(void)
-{
-    ...
-    SCB->VTOR = FLASH_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal FLASH */
-  ...
-}
-```
+You also have to add the precompilation flag `-D WITH_BOOTLOADER` to the platformio.ini file of your application. Now your application is ready to be flashed using a bootloader.
 
 :::info
 You can find application examples in [the Luos engine's repository](https://github.com/Luos-io/luos_engine/tree/main/Examples/Projects).
 :::
-
-### How to deal with no VTOR
-
-Some CPUs don't have a VTOR register (such as all CPUs based on cortex-m0), so you have to emulate one. The more convenient solution consists of using a section in RAM to save the application vector table. Then we have to find a way for the CPU to look to this section when it has to check the vector table (by default, it will always look at the first address of the flash memory).
-
-To do so, we modify the application linker to add a dedicated section in RAM:
-
-<div align="center">
-  <Image src="/img/linker_ram1.png" />
-</div>
-
-<div align="center">
-  <Image src="/img/linker_ram2.png" />
-</div>
-
-Then, we initialize an empty vector table in this section:
-
-```c
-#define RSVD_SECTION ".rsvd.data,\"aw\",%nobits//"
-#define _RSVD __attribute__((used, section(RSVD_SECTION)))
-
-static volatile _RSVD uint32_t VectorTable[48];
-```
-
-Now we copy the application vector table in RAM in the `main()` function:
-
-```c
-for (i = 0; i < 48; i++)
-{
-    VectorTable[i] = *(__IO uint32_t *)(0x0800C800 + (i << 2));
-}
-
-/* Enable the SYSCFG peripheral clock*/
-__HAL_RCC_SYSCFG_CLK_ENABLE();
-/* Remap SRAM at 0x00000000 */
-__HAL_SYSCFG_REMAPMEMORY_SRAM();
-```
-
-The last line remaps the CPU to the RAM, allowing the CPU to check the vector table at the first address of RAM instead of FLASH.

--- a/docs/tools/boot.mdx
+++ b/docs/tools/boot.mdx
@@ -149,9 +149,10 @@ No matter what problem you encounter during the loading process, you have to pow
 
 ### ST-Link connected gate
 
-If for the communication of the gate with your computer, you are using the ST-Link protocol, and the flashing process is blocked in the last step of flashing with no specific reason, then you may have come through a specific problem caused by the ST-Link driver, with a specific size of binary, when flashing with a Luos bootloader.
+If you are using the ST-Link protocol for the communication of the gate with your computer and the flashing process is blocked in the last step of flashing with no specific reason, then you may have come through a specific problem caused by the ST-Link driver. It happens with a specific size of binary, when flashing with a Luos bootloader.
+
 :::tip
-To reasure yourself that this is the case, you can try changing the size of your binary by changing some bytes of your code, or you can use an other way to connect your gate, like for example FTDI, and retry to flash your application with Luos bootloader. 
+To resolve this issue, you can try to change the size of your binary by changing some bytes of your code, or you can use an other way to connect your gate, like for example FTDI, and retry flashing your application with Luos bootloader. 
 :::
 
 ## How to add the bootloader feature in your project
@@ -218,18 +219,18 @@ This figure shows a third section called **shared_flash**, which exchanges infor
 
 ### Flash memory remapping
 
-In each different Luos compatible board, we propose a default configuration of the flash memory. That is to say, by default, the bootloader's code is placed in the beginning of flash, then we place the Shared memory, and at the end we position the applications code, like explained in the above image. However, we give you the possibility to configure the flash as you want, by exposing some macros that you can redefine in the node_config.h file of your bootloader or application. These are:
+In each different Luos compatible board, we propose a default configuration of the flash memory. By default, the bootloader's code is placed in the beginning of the flash. Then there is the shared memory, and at the end we can found the applications' code, like explained in the image above. However, we give you the possibility to configure the flash as you want, by exposing some macros that you can redefine in the file *node_config.h* in the bootloader or in the application. These macros are the following:
 
 
   | Define                | Description                                                                                |
   |:---------------------:|:-------------------------------------------------------------------------------------------:
-  | BOOT_START_ADDRESS    | Start address of Bootloader in flash                                                       |
-  | SHARED_MEMORY_ADDRESS | Start address of shared memory to save boot flag                                           |
-  | SHARED_MEMORY_SECTOR  | Start sector of shared memory (in case of boards with flash in sectors)                    |
-  | APP_START_ADDRESS     | Start address of application with bootloader                                               |
-  | APP_END_ADDRESS       | End address of application with bootloader                                                 |
-  | APP_START_SECTOR      | Start sector of application with bootloader (in case of boards with flash in sectors)      |
-  | APP_END_SECTOR        | last sector of application with bootloader (in case of boards with flash in sectors)       |
+  | BOOT_START_ADDRESS    | Start address of the bootloader in the flash                                               |
+  | SHARED_MEMORY_ADDRESS | Start address of the shared memory to save boot flag                                       |
+  | SHARED_MEMORY_SECTOR  | Start sector of the shared memory (in case of boards with flash in sectors)                |
+  | APP_START_ADDRESS     | Start address of the application with bootloader                                           |
+  | APP_END_ADDRESS       | End address of the application with bootloader                                             |
+  | APP_START_SECTOR      | Start sector of the application with bootloader (in case of boards with flash in sectors)  |
+  | APP_END_SECTOR        | Last sector of the application with bootloader (in case of boards with flash in sectors)   |
 
 ### Applications
 
@@ -239,7 +240,7 @@ As for the bootloader, you have to modify your linker file in the application if
   <Image src="/img/linker_app.png" />
 </div>
 
-You also have to add the precompilation flag `-D WITH_BOOTLOADER` to the platformio.ini file of your application. Now your application is ready to be flashed using a bootloader.
+You also have to add the precompilation flag `-D WITH_BOOTLOADER` to the file *platformio.ini* in your application. Your application is now ready to be flashed using a bootloader.
 
 :::info
 You can find application examples in [the Luos engine's repository](https://github.com/Luos-io/luos_engine/tree/main/Examples/Projects).

--- a/faq/005.stlink.mdx
+++ b/faq/005.stlink.mdx
@@ -4,7 +4,7 @@ custom_edit_url: null
 
 import Image from "@site/src/components/Images.js";
 
-# I am enable to update my board using ST-Link
+# I am unable to update my board using ST-Link
 
 ## Symptom(s)
 
@@ -16,7 +16,7 @@ Your ST-Link driver is not installed.
 
 ## Resolution
 
-### Download the ST -Link driver for your platform
+### Download the ST-Link driver for your platform
 
 You may need to download and install the ST-Link driver for your OS (ST website might ask you to login or register):
 

--- a/faq/008.stlink_bootbug.mdx
+++ b/faq/008.stlink_bootbug.mdx
@@ -1,0 +1,23 @@
+---
+custom_edit_url: null
+---
+
+import Image from "@site/src/components/Images.js";
+
+# I am unable to flash my board with Luos bootloader, when using ST-Link connected gate
+
+## Symptom(s)
+
+When you try to update a card using Luos bootloader, in a network connected with your computer using ST-Link, the process fails in the last step of flashing.
+
+## Possible explanation
+
+This is possibly a bug of the ST-Link driver, that arrives with a specific size of messages, so with a specific size of binary files.
+
+## Resolution
+
+Try to connect your gate to your computer using an other protocol like FTDI, or try to resize the .bin file you want to flash, by slightly changing your application's code.
+
+
+
+

--- a/faq/008.stlink_bootbug.mdx
+++ b/faq/008.stlink_bootbug.mdx
@@ -8,16 +8,12 @@ import Image from "@site/src/components/Images.js";
 
 ## Symptom(s)
 
-When you try to update a card using Luos bootloader, in a network connected with your computer using ST-Link, the process fails in the last step of flashing.
+When you try to update a Luos board using the bootloader in a network connected with your computer using ST-Link, the process fails during the last step of flashing.
 
 ## Possible explanation
 
-This is possibly a bug of the ST-Link driver, that arrives with a specific size of messages, so with a specific size of binary files.
+This may be a bug from the ST-Link driver occuring with a specific size of messages, and so a specific size of binary files.
 
 ## Resolution
 
-Try to connect your gate to your computer using an other protocol like FTDI, or try to resize the .bin file you want to flash, by slightly changing your application's code.
-
-
-
-
+Try to connect your gate to your computer using another protocol, like FTDI, and flash again. If it doesn't work, try to resize the *.bin* file you want to flash, by slightly changing your application's code.


### PR DESCRIPTION
⚠ PLEASE DO NOT DELETE THE TEXT BELOW ⚠

## Pull request's description

*Add here a description of the modifications you made.*
1.Bootloader update
2. stlink troubleshooting page for bootloader
3. typos in stlink page
## Checklist before merging (please do not edit)
You must review you work before to submit the review to others.

### Self-review of your content
Remember the content must be readable and understandable by someone else than yourself.
- [ ] From a technical point of view.
- [ ] From a grammatical point of view (spelling mistakes, typos, clarity, etc.), and following the guidelines at the bottom.

### External reviews of your content
- [ ] You requested a technical review.
- [ ] You requested a grammatical review.
- [ ] You validated with @K0rdan or @alexgeron-Luos that it is safe to merge.

### Some guidelines to keep in mind
- Colons (:), semi-colons (;), exclamation (!), and interrogation points (?) are not preceded by a space (like full stops and commas). E.g.: Colons!
- File names and/or address are put in *italic*. E.g.: The file _main.c_.
- Functions, variables, or more generally short codes are put between grave accents. E.g.: To obtain `code()`, type \`code()\`.
- Long codes are put into blocks of code with three grave accent on each side, and the language's name:<br />
\`\`\`c<br />
// Some C language <br />
\`\`\`<br />

- "Luos engine" has a upper case on the **L** for "Luos" and lower case on the **e** for "engine".
- We call it "Luos engine" as a proper name, and ***not*** "the Luos engine".
- Following that fashion, anything that's owned by "Luos engine" implies that we must use `'s` as the standard English rule to show the possessive case, e.g. "Luos engine's API".
- The names pipe, gate, inspector, sniffer, app or application, driver, etc. have a lower case and can be refereed with the determiner `the`. E.g.: The inspector.
