### PR TITLE
Multicast

### DIFF
--- a/docs/luos-technology/message/message.mdx
+++ b/docs/luos-technology/message/message.mdx
@@ -50,7 +50,7 @@ typedef struct{
   - **IDACK**: This mode allows to communicate with a unique service using its ID **with** acknowledgment return.
   - **TYPE**: This mode sends a message to all services with a given type, e.g. all "Sharp digital distance sensor".
   - **BROADCAST**: This mode allows all the services in the network to catch a message. In this case, the message contains a type of data used by multiple services.
-  - **TOPIC**: Publisher/Subscriber mode, allows multiple services to catch a message depending on the topic that they are subscribed to. 
+  - **TOPIC**: Publisher/Subscriber mode, allows multiple services to catch a message depending on the topic that they subscribed to. 
   - **NODEID**: This mode allows to send a message to all the services of a specific node **without** acknowledgment return.
   - **NODEIDACK**: This mode allows to send a message to all the services of a specific node **with** acknowledgment return.
 - **Source (12 bits)**: The unique ID of the transmitter service.

--- a/docs/luos-technology/message/message.mdx
+++ b/docs/luos-technology/message/message.mdx
@@ -35,9 +35,9 @@ here is the `header_t` structure:
 ```c
 typedef struct{
     uint16_t protocol : 4;    /*!< Protocol version. */
-    uint16_t target : 12;     /*!< Target address, it can be (ID, Multicast/Broadcast, Type). */
-    uint16_t target_mode : 4; /*!< Select targeting mode (ID, ID+ACK, Multicast/Broadcast, Type). */
-    uint16_t source : 12;     /*!< Source address, it can be (ID, Multicast/Broadcast, Type). */
+    uint16_t target : 12;     /*!< Target address, it can be (ID, Topic,Broadcast, Type). */
+    uint16_t target_mode : 4; /*!< Select targeting mode (ID, ID+ACK, Topic, Broadcast, Type). */
+    uint16_t source : 12;     /*!< Source address, it can be (ID, Topic, Broadcast, Type). */
     uint8_t cmd;              /*!< msg definition. */
     uint16_t size;            /*!< Size of the data field. */
 }header_t;
@@ -48,8 +48,9 @@ typedef struct{
 - **Target_mode (4 bits)**: This field indicates the addressing mode and how to understand the _Target_ field. It can take different values:
   - **ID**: This mode allows to communicate with a unique service using its ID **without** acknowledgment return.
   - **IDACK**: This mode allows to communicate with a unique service using its ID **with** acknowledgment return.
-  - **Type**: This mode sends a message to all services with a given type, e.g. all "Sharp digital distance sensor".
-  - **Multicast/Broadcast**: This mode allows multiple services to catch a message. In this case, the message contains a type of data used by multiple services.
+  - **TYPE**: This mode sends a message to all services with a given type, e.g. all "Sharp digital distance sensor".
+  - **BROADCAST**: This mode allows all the services in the network to catch a message. In this case, the message contains a type of data used by multiple services.
+  - **TOPIC**: Publisher/Subscriber mode, allows multiple services to catch a message depending on the topic that they are subscribed to. 
   - **NODEID**: This mode allows to send a message to all the services of a specific node **without** acknowledgment return.
   - **NODEIDACK**: This mode allows to send a message to all the services of a specific node **with** acknowledgment return.
 - **Source (12 bits)**: The unique ID of the transmitter service.

--- a/docs/luos-technology/services/service-api.mdx
+++ b/docs/luos-technology/services/service-api.mdx
@@ -140,6 +140,7 @@ Luos engine includes the following tools to integrate more capabilities and func
 |                        Description                         |                                       Function                                        |               Return                |
 | :--------------------------------------------------------: | :-----------------------------------------------------------------------------------: | :---------------------------------: |
 |                    Send a Luos message                     |                    `Luos_SendMsg(service_t *service, msg_t *msg);`                    |          `error_return_t`           |
+|              Send a timestamped Luos message               |    `Luos_SendTimestampMsg(service_t *service, msg_t *msg, time_luos_t timestamp);`    |          `error_return_t`           |
 |                    Read a Luos message                     |               `Luos_ReadMsg(service_t *service, msg_t **returned_msg);`               |          `error_return_t`           |
 |      Send the remaining data in case of long messages      |    `Luos_SendData(service_t *service, msg_t *msg, void *bin_data, uint16_t size);`    |               `void`                |
 |    Receive the remaining data in case of long messages     |          `Luos_ReceiveData(service_t *service, msg_t *msg, void *bin_data);`          | `data size at the end of reception` |
@@ -147,3 +148,6 @@ Luos engine includes the following tools to integrate more capabilities and func
 |           Receive data from a streaming channel            | `Luos_ReceiveStreaming(service_t *service, msg_t *msg, streaming_channel_t *stream);` |          `error_return_t`           |
 |                  Share network's baudrate                  |              `Luos_SendBaudrate(service_t *service, uint32_t baudrate);`              |               `void`                |
 | Get the total ticks number since the initialization        |                               `Luos_GetSystick(void);`                                |             `uint32_t`              |
+|       Subscribe to a new topic for MULTICAST messages      |               `Luos_TopicSubscribe(service_t *service, uint16_t topic);`              |          `error_return_t`           |
+|       Unsubscribe from a topic for MULTICAST messages      |              `Luos_TopicUnsubscribe(service_t *service, uint16_t topic);`             |          `error_return_t`           |
+| Activate/Deactivate message filtering for global reception |               `Luos_SetFilterState(uint8_t state, service_t *service);`               |               `void`                |

--- a/docs/luos-technology/services/service-api.mdx
+++ b/docs/luos-technology/services/service-api.mdx
@@ -148,6 +148,6 @@ Luos engine includes the following tools to integrate more capabilities and func
 |           Receive data from a streaming channel            | `Luos_ReceiveStreaming(service_t *service, msg_t *msg, streaming_channel_t *stream);` |          `error_return_t`           |
 |                  Share network's baudrate                  |              `Luos_SendBaudrate(service_t *service, uint32_t baudrate);`              |               `void`                |
 | Get the total ticks number since the initialization        |                               `Luos_GetSystick(void);`                                |             `uint32_t`              |
-|       Subscribe to a new topic for MULTICAST messages      |               `Luos_TopicSubscribe(service_t *service, uint16_t topic);`              |          `error_return_t`           |
-|       Unsubscribe from a topic for MULTICAST messages      |              `Luos_TopicUnsubscribe(service_t *service, uint16_t topic);`             |          `error_return_t`           |
+|        Subscribe to a new topic for pub/sub messages       |               `Luos_TopicSubscribe(service_t *service, uint16_t topic);`              |          `error_return_t`           |
+|        Unsubscribe from a topic for pub/sub messages       |              `Luos_TopicUnsubscribe(service_t *service, uint16_t topic);`             |          `error_return_t`           |
 | Activate/Deactivate message filtering for global reception |               `Luos_SetFilterState(uint8_t state, service_t *service);`               |               `void`                |


### PR DESCRIPTION
⚠ PLEASE DO NOT DELETE THE TEXT BELOW ⚠

## Pull request's description

*Add here a description of the modifications you made.*

## Checklist before merging (please do not edit)
You must review you work before to submit the review to others.

### Self-review of your content
Remember the content must be readable and understandable by someone else than yourself.
- [ ] From a technical point of view.
- [ ] From a grammatical point of view (spelling mistakes, typos, clarity, etc.), and following the guidelines at the bottom.

### External reviews of your content
- [ ] You requested a technical review.
- [ ] You requested a grammatical review.
- [ ] You validated with @K0rdan or @alexgeron-Luos that it is safe to merge.

### Some guidelines to keep in mind
- Colons (:), semi-colons (;), exclamation (!), and interrogation points (?) are not preceded by a space (like full stops and commas). E.g.: Colons!
- File names and/or address are put in *italic*. E.g.: The file _main.c_.
- Functions, variables, or more generally short codes are put between grave accents. E.g.: To obtain `code()`, type \`code()\`.
- Long codes are put into blocks of code with three grave accent on each side, and the language's name:<br />
\`\`\`c<br />
// Some C language <br />
\`\`\`<br />

- "Luos engine" has a upper case on the **L** for "Luos" and lower case on the **e** for "engine".
- We call it "Luos engine" as a proper name, and ***not*** "the Luos engine".
- Following that fashion, anything that's owned by "Luos engine" implies that we must use `'s` as the standard English rule to show the possessive case, e.g. "Luos engine's API".
- The names pipe, gate, inspector, sniffer, app or application, driver, etc. have a lower case and can be refereed with the determiner `the`. E.g.: The inspector.
