### PR TITLE
add esp32 compatibility

### DIFF
--- a/docs/compatibility/mcu_demoboard.mdx
+++ b/docs/compatibility/mcu_demoboard.mdx
@@ -45,6 +45,15 @@ Below is the list of the MCUs directly compatible with Luos engine:
 |                  |             ATSAMD21Gxx             |                                                         |
 |                  |             ATSAMD21Jxx             |      HAL default configuration on SAMDJ18A              |
 
+### ESP32
+
+|      Family      |                MCU                  |                       Description                       |
+| :--------------: | :---------------------------------: |-------------------------------------------------------: |
+|       ESP32      |                ESP32                |         HAL default configuration on ESP32              |
+|                  |               ESP32-C3              |                                                         |
+|                  |               ESP32-S2              |                                                         |
+|                  |               ESP32-S3              |                                                         |
+
 ### Demo boards
 
 |                Board                 |                                 Description                               |
@@ -74,4 +83,18 @@ Below is the list of the MCUs directly compatible with Luos engine:
 |      ARDUINO_SAMD_MKRNB1500          |                                                                           |
 |     ARDUINO_SAMD_NANO_33_IOT         |                                                                           |
 |     ARDUINO_SAMD_MKRVIDOR4000        |                                                                           |
+|          ESP32-S2-DEVKITM-1          |                                                                           |
+|          ESP32-S2-DEVKITC-1          |                  HAL default configuration on ESP32-S2/S3                 |
+|          ESP32-S2-KALUGA-1           |                                                                           |
+|          ESP32-S2-SAOLA-1            |                                                                           |
+|          ESP32-S3-DEVKITC-1          |                                                                           |
+|          ESP32-S3-DEVKITM-1          |                                                                           |
+|          ESP32-S3-EYE                |                                                                           |
+|          ESP32-C3-DEVKITM-1          |                  HAL default configuration on ESP32-C3                    |
+|          ESP32-C3-DEVKITC-02         |                                                                           |
+|          ESP32-DEVKITC-1             |                    HAL default configuration on ESP32                     |
+|          ESP32-DEVKITM-1             |                                                                           |
+|          ESP-WROVER-KIT              |                                                                           |
+|          ESP-EYE                     |                                                                           |
+
 


### PR DESCRIPTION
⚠ PLEASE DO NOT DELETE THE TEXT BELOW ⚠

## Pull request's description

*Add here a description of the modifications you made.*

## Checklist before merging (please do not edit)
You must review you work before to submit the review to others.

### Self-review of your content
Remember the content must be readable and understandable by someone else than yourself.
- [ ] From a technical point of view.
- [ ] From a grammatical point of view (spelling mistakes, typos, clarity, etc.), and following the guidelines at the bottom.

### External reviews of your content
- [ ] You requested a technical review.
- [ ] You requested a grammatical review.
- [ ] You validated with @K0rdan or @alexgeron-Luos that it is safe to merge.

### Some guidelines to keep in mind
- Colons (:), semi-colons (;), exclamation (!), and interrogation points (?) are not preceded by a space (like full stops and commas). E.g.: Colons!
- File names and/or address are put in *italic*. E.g.: The file _main.c_.
- Functions, variables, or more generally short codes are put between grave accents. E.g.: To obtain `code()`, type \`code()\`.
- Long codes are put into blocks of code with three grave accent on each side, and the language's name:<br />
\`\`\`c<br />
// Some C language <br />
\`\`\`<br />

- "Luos engine" has a upper case on the **L** for "Luos" and lower case on the **e** for "engine".
- We call it "Luos engine" as a proper name, and ***not*** "the Luos engine".
- Following that fashion, anything that's owned by "Luos engine" implies that we must use `'s` as the standard English rule to show the possessive case, e.g. "Luos engine's API".
- The names pipe, gate, inspector, sniffer, app or application, driver, etc. have a lower case and can be refereed with the determiner `the`. E.g.: The inspector.
