### PR TITLE
Troubleshooting page for arduino upload

### DIFF
--- a/faq/008.upload_arduino_bug.mdx
+++ b/faq/008.upload_arduino_bug.mdx
@@ -1,0 +1,20 @@
+---
+custom_edit_url: null
+---
+
+import Image from "@site/src/components/Images.js";
+
+# I can't upload my Arduino project
+
+## Symptom(s)
+
+When you try to update an Arduino board, an error message may appear on platformio.ini. This error concerns an upload problem of arduino, even though you do not have any compilation errors.
+
+## Possible explanation
+
+You need to restart your Arduino board so as to be ready to be flashed.
+
+## Resolution
+
+Double click your Arduino's reset button, so that it gets in boot mode and try to relaunch the upload of your firmware.
+

--- a/faq/index.mdx
+++ b/faq/index.mdx
@@ -15,6 +15,7 @@ description: What is your issue? Get answers to the most frequently asked questi
 - [I am enable to update my board using ST-Link.](/faq/stlink)
 - [I can't complete the get started tutorial because some dependencies are not installed.](/faq/install-development-environment)
 - [My board is not detected in the network](/faq/board-not-detected-network)
+- [I can't upload my Arduino project](/faq/upload_arduino_bug)
 
 ---
 


### PR DESCRIPTION
⚠ PLEASE DO NOT DELETE THE TEXT BELOW ⚠

## Pull request's description

*Add here a description of the modifications you made.*

## Checklist before merging (please do not edit)
You must review you work before to submit the review to others.

### Self-review of your content
Remember the content must be readable and understandable by someone else than yourself.
- [ ] From a technical point of view.
- [ ] From a grammatical point of view (spelling mistakes, typos, clarity, etc.), and following the guidelines at the bottom.

### External reviews of your content
- [ ] You requested a technical review.
- [ ] You requested a grammatical review.
- [ ] You validated with @K0rdan or @alexgeron-Luos that it is safe to merge.

### Some guidelines to keep in mind
- Colons (:), semi-colons (;), exclamation (!), and interrogation points (?) are not preceded by a space (like full stops and commas). E.g.: Colons!
- File names and/or address are put in *italic*. E.g.: The file _main.c_.
- Functions, variables, or more generally short codes are put between grave accents. E.g.: To obtain `code()`, type \`code()\`.
- Long codes are put into blocks of code with three grave accent on each side, and the language's name:<br />
\`\`\`c<br />
// Some C language <br />
\`\`\`<br />

- "Luos engine" has a upper case on the **L** for "Luos" and lower case on the **e** for "engine".
- We call it "Luos engine" as a proper name, and ***not*** "the Luos engine".
- Following that fashion, anything that's owned by "Luos engine" implies that we must use `'s` as the standard English rule to show the possessive case, e.g. "Luos engine's API".
- The names pipe, gate, inspector, sniffer, app or application, driver, etc. have a lower case and can be refereed with the determiner `the`. E.g.: The inspector.
