### PR TITLE
Add some redirections

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -57,6 +57,11 @@
       "statusCode": 301
     },
     {
+      "source": "/docs/luos-technology/node/node",
+      "destination": "/docs/luos-technology/node",
+      "statusCode": 301
+    },
+    {
       "source": "/docs/luos-technology/package/package",
       "destination": "/docs/luos-technology/package",
       "statusCode": 301
@@ -99,6 +104,11 @@
     {
       "source": "/get-started(.*)",
       "destination": "/tutorials/get-started",
+      "statusCode": 301
+    },
+    {
+      "source": "/legal-notice",
+      "destination": "/docs/luos-technology",
       "statusCode": 301
     },
     {
@@ -259,6 +269,11 @@
     {
       "source": "/tutorials/tutorials(.*)",
       "destination": "/tutorials",
+      "statusCode": 301
+    },
+    {
+      "source": "/tutorials/luos-and-tools/arduino",
+      "destination": "/tutorials/arduino/intro",
       "statusCode": 301
     },
     {


### PR DESCRIPTION
Add 301 redirects to avoid 404

⚠ PLEASE DO NOT DELETE THE TEXT BELOW ⚠

## Pull request's description

*Add here a description of the modifications you made.*

## Checklist before merging (please do not edit)
You must review you work before to submit the review to others.

### Self-review of your content
Remember the content must be readable and understandable by someone else than yourself.
- [ ] From a technical point of view.
- [ ] From a grammatical point of view (spelling mistakes, typos, clarity, etc.), and following the guidelines at the bottom.

### External reviews of your content
- [ ] You requested a technical review.
- [ ] You requested a grammatical review.
- [ ] You validated with @K0rdan or @alexgeron-Luos that it is safe to merge.

### Some guidelines to keep in mind
- Colons (:), semi-colons (;), exclamation (!), and interrogation points (?) are not preceded by a space (like full stops and commas). E.g.: Colons!
- File names and/or address are put in *italic*. E.g.: The file _main.c_.
- Functions, variables, or more generally short codes are put between grave accents. E.g.: To obtain `code()`, type \`code()\`.
- Long codes are put into blocks of code with three grave accent on each side, and the language's name:<br />
\`\`\`c<br />
// Some C language <br />
\`\`\`<br />

- "Luos engine" has a upper case on the **L** for "Luos" and lower case on the **e** for "engine".
- We call it "Luos engine" as a proper name, and ***not*** "the Luos engine".
- Following that fashion, anything that's owned by "Luos engine" implies that we must use `'s` as the standard English rule to show the possessive case, e.g. "Luos engine's API".
- The names pipe, gate, inspector, sniffer, app or application, driver, etc. have a lower case and can be refereed with the determiner `the`. E.g.: The inspector.
