### PR TITLE
remove slash

### DIFF
--- a/src/components/school/index/data/dataIntro.json
+++ b/src/components/school/index/data/dataIntro.json
@@ -21,7 +21,7 @@
       "img": "Get_Started_Luos",
       "desc": "The Get started allows you to build, flash, run, and control your very first Luos project.",
       "tags": ["Board", "MCU", "Service", "Network", "Distributed system"],
-      "link": "/tutorials/get-started/",
+      "link": "/tutorials/get-started",
       "author": "nicoR"
     },
     {
@@ -33,7 +33,7 @@
       "img": "Your_first_service_Luos",
       "desc": "You just finished Luos get started and you want to go further with Luos: this tutorial is for you!",
       "tags": ["Service", "Package", "Handler", "Gate", "Pipe"],
-      "link": "/tutorials/your-first-service/",
+      "link": "/tutorials/your-first-service",
       "author": "thomas"
     },
     {
@@ -45,7 +45,7 @@
       "img": "Your_first_message_Luos",
       "desc": "Luos aim to exchange information between services by sending messages. In this tutorial we will learn the message structure and how to send it to another services.",
       "tags": ["Luos Message", "Service", "Polling", "Message Handler"],
-      "link": "/tutorials/your-first-message/",
+      "link": "/tutorials/your-first-message",
       "author": "nicoC"
     },
     {
@@ -57,7 +57,7 @@
       "img": "Your_First_Topology_detection_Luos",
       "desc": "Since the beginning of this training, we discover how to create services, deal with messages and control them using Pyluos. But we never create any embedded application service using other services.",
       "tags": ["Service", "Topology", "Detection", "Application"],
-      "link": "/tutorials/your-first-detection/",
+      "link": "/tutorials/your-first-detection",
       "author": "viktoria"
     },
     {


### PR DESCRIPTION
⚠ PLEASE DO NOT DELETE THE TEXT BELOW ⚠

## Pull request's description

*Add here a description of the modifications you made.*

## Checklist before merging (please do not edit)
You must review you work before to submit the review to others.

### Self-review of your content
Remember the content must be readable and understandable by someone else than yourself.
- [ ] From a technical point of view.
- [ ] From a grammatical point of view (spelling mistakes, typos, clarity, etc.), and following the guidelines at the bottom.

### External reviews of your content
- [ ] You requested a technical review.
- [ ] You requested a grammatical review.
- [ ] You validated with @K0rdan or @alexgeron-Luos that it is safe to merge.

### Some guidelines to keep in mind
- Colons (:), semi-colons (;), exclamation (!), and interrogation points (?) are not preceded by a space (like full stops and commas). E.g.: Colons!
- File names and/or address are put in *italic*. E.g.: The file _main.c_.
- Functions, variables, or more generally short codes are put between grave accents. E.g.: To obtain `code()`, type \`code()\`.
- Long codes are put into blocks of code with three grave accent on each side, and the language's name:<br />
\`\`\`c<br />
// Some C language <br />
\`\`\`<br />

- "Luos engine" has a upper case on the **L** for "Luos" and lower case on the **e** for "engine".
- We call it "Luos engine" as a proper name, and ***not*** "the Luos engine".
- Following that fashion, anything that's owned by "Luos engine" implies that we must use `'s` as the standard English rule to show the possessive case, e.g. "Luos engine's API".
- The names pipe, gate, inspector, sniffer, app or application, driver, etc. have a lower case and can be refereed with the determiner `the`. E.g.: The inspector.
