### PR TITLE
Fix 404 broken links using Semrush file #2

### DIFF
--- a/docs/hardware-consideration/test-your-configuration.mdx
+++ b/docs/hardware-consideration/test-your-configuration.mdx
@@ -1,7 +1,10 @@
+---
+custom_edit_url: null
+---
 # Test your Robus configuration
 
 To adapt Luos engine to your board specificities, you need to configure it. This subject is covered in the [Luos engine configuration](./mcu).
-To validate your Robus network's hardware configuration, you can use a Robus tool called _selftest_ available in the <a href="https://github.com/Luos-io/luos_engine/tree/main/network/robus/selftest" target="_blank" rel="external nofollow">Luos engine's 'library<IconExternalLink width="10"></IconExternalLink></a>.
+To validate your Robus network's hardware configuration, you can use a Robus tool called _selftest_ available in the <a href="https://github.com/Luos-io/luos_engine/tree/main/network/robus/selftest" target="_blank" rel="external nofollow">Luos engine's 'library.<IconExternalLink width="10"></IconExternalLink></a>
 
 ## Hardware test conditions
 

--- a/docs/luos-technology/services/profile.mdx
+++ b/docs/luos-technology/services/profile.mdx
@@ -1,3 +1,6 @@
+---
+custom_edit_url: null
+---
 # Luos engine services profiles
 
 ## What is a service profile

--- a/tutorials/arduino/intro.mdx
+++ b/tutorials/arduino/intro.mdx
@@ -33,7 +33,7 @@ import Introduction from '/src/components/school/article/intro.js';
   ressources={[
     {
       label: 'Arduino zero',
-      link: 'https://www.arduino.cc/en/Main/ArduinoBoardZero&',
+      link: 'https://docs.arduino.cc/hardware/zero',
     },
     {
       label: 'MKRzero',
@@ -41,7 +41,7 @@ import Introduction from '/src/components/school/article/intro.js';
     },
     {
       label: 'MKR1000',
-      link: 'https://store.arduino.cc/collections/boards/products/arduino-mkr1000-wifi',
+      link: 'https://docs.arduino.cc/hardware/mkr-1000-wifi',
     },
     {
       label: 'Any SAMD21-based Arduino board',

--- a/tutorials/your-first-detection/your-first-detection.mdx
+++ b/tutorials/your-first-detection/your-first-detection.mdx
@@ -41,7 +41,7 @@ import Introduction from '/src/components/school/article/intro.js';
   ressources={[
     {
       label: 'Arduino zero',
-      link: 'https://www.arduino.cc/en/Main/ArduinoBoardZero&',
+      link: 'https://docs.arduino.cc/hardware/zero',
     },
     {
       label: 'MKRzero',

--- a/tutorials/your-first-message/your-first-message.mdx
+++ b/tutorials/your-first-message/your-first-message.mdx
@@ -37,7 +37,7 @@ import Introduction from '/src/components/school/article/intro.js';
   ressources={[
     {
       label: 'Arduino zero',
-      link: 'https://www.arduino.cc/en/Main/ArduinoBoardZero&',
+      link: 'https://docs.arduino.cc/hardware/zero',
     },
     {
       label: 'MKRzero',
@@ -45,7 +45,7 @@ import Introduction from '/src/components/school/article/intro.js';
     },
     {
       label: 'MKR1000',
-      link: 'https://store.arduino.cc/collections/boards/products/arduino-mkr1000-wifi',
+      link: 'https://docs.arduino.cc/hardware/mkr-1000-wifi',
     },
     {
       label: 'STM32L432KC',

--- a/tutorials/your-first-service/your-first-service.mdx
+++ b/tutorials/your-first-service/your-first-service.mdx
@@ -29,7 +29,7 @@ import Introduction from '/src/components/school/article/intro.js';
   ressources={[
     {
       label: 'Arduino zero',
-      link: 'https://www.arduino.cc/en/Main/ArduinoBoardZero&',
+      link: 'https://docs.arduino.cc/hardware/zero',
     },
     {
       label: 'MKRzero',
@@ -37,7 +37,7 @@ import Introduction from '/src/components/school/article/intro.js';
     },
     {
       label: 'MKR1000',
-      link: 'https://store.arduino.cc/collections/boards/products/arduino-mkr1000-wifi',
+      link: 'https://docs.arduino.cc/hardware/mkr-1000-wifi',
     },
     {
       label: 'STM32L432KC',

--- a/versioned_docs/version-2.5.0/hardware-consideration/test-your-configuration.mdx
+++ b/versioned_docs/version-2.5.0/hardware-consideration/test-your-configuration.mdx
@@ -1,7 +1,10 @@
+---
+custom_edit_url: null
+---
 # Test your Robus configuration
 
 To adapt Luos engine to your board specificities, you need to configure it. This subject is covered in the [Luos engine configuration](./mcu).
-To validate your Robus network's hardware configuration, you can use a Robus tool called _selftest_ available in the <a href="https://github.com/Luos-io/luos_engine/tree/main/network/robus/selftest" target="_blank" rel="external nofollow">Luos engine's 'library<IconExternalLink width="10"></IconExternalLink></a>.
+To validate your Robus network's hardware configuration, you can use a Robus tool called _selftest_ available in the <a href="https://github.com/Luos-io/luos_engine/tree/main/network/robus/selftest" target="_blank" rel="external nofollow">Luos engine's 'library.<IconExternalLink width="10"></IconExternalLink></a>
 
 ## Hardware test conditions
 

--- a/versioned_docs/version-2.5.0/luos-technology/services/profile.mdx
+++ b/versioned_docs/version-2.5.0/luos-technology/services/profile.mdx
@@ -1,3 +1,6 @@
+---
+custom_edit_url: null
+---
 # Luos engine services profiles
 
 ## What is a service profile


### PR DESCRIPTION
⚠ PLEASE DO NOT DELETE THE TEXT BELOW ⚠

## Pull request's description

*Add here a description of the modifications you made.*

## Checklist before merging (please do not edit)
You must review you work before to submit the review to others.

### Self-review of your content
Remember the content must be readable and understandable by someone else than yourself.
- [ ] From a technical point of view.
- [ ] From a grammatical point of view (spelling mistakes, typos, clarity, etc.), and following the guidelines at the bottom.

### External reviews of your content
- [ ] You requested a technical review.
- [ ] You requested a grammatical review.
- [ ] You validated with @K0rdan or @alexgeron-Luos that it is safe to merge.

### Some guidelines to keep in mind
- Colons (:), semi-colons (;), exclamation (!), and interrogation points (?) are not preceded by a space (like full stops and commas). E.g.: Colons!
- File names and/or address are put in *italic*. E.g.: The file _main.c_.
- Functions, variables, or more generally short codes are put between grave accents. E.g.: To obtain `code()`, type \`code()\`.
- Long codes are put into blocks of code with three grave accent on each side, and the language's name:<br />
\`\`\`c<br />
// Some C language <br />
\`\`\`<br />

- "Luos engine" has a upper case on the **L** for "Luos" and lower case on the **e** for "engine".
- We call it "Luos engine" as a proper name, and ***not*** "the Luos engine".
- Following that fashion, anything that's owned by "Luos engine" implies that we must use `'s` as the standard English rule to show the possessive case, e.g. "Luos engine's API".
- The names pipe, gate, inspector, sniffer, app or application, driver, etc. have a lower case and can be refereed with the determiner `the`. E.g.: The inspector.
