### PR TITLE
Put "test your skills" at the end and added a title number

### DIFF
--- a/tutorials/get-started/get-started1.mdx
+++ b/tutorials/get-started/get-started1.mdx
@@ -152,10 +152,11 @@ On top of it, we also added two other services allowing you to take control of y
 - **Pipe**, managing a serial interface.<br /> ╰ The code folder of this service is located in the cloud (because it is a common cross-platform's Luos tool), PlatformIO just downloaded it for you.
 - **Gate**, an app that translates Luos engine's messages to JSON and sends it through the _Pipe_.<br /> ╰ The code folder of this service is located in the cloud (because it is a common cross-platform's Luos tool), PlatformIO just downloaded it for you.
 
-## Test your skills
+## 7. Next step
+
+Your development environment is now configured, and the Get started project is installed in a local folder of your choice. The [next part](/tutorials/get-started/get-started2) of this section will teach you how to run Luos on your MCU and take the control with high level API!
+
+## 8. Test your skills
 
 <Form id="uAfY4YhI" />
 
-## Next step
-
-Your development environment is now configured, and the Get started project is installed in a local folder of your choice. The [next part](/tutorials/get-started/get-started2) of this section will teach you how to run Luos on your MCU and take the control with high level API!

--- a/tutorials/get-started/get-started2.mdx
+++ b/tutorials/get-started/get-started2.mdx
@@ -139,10 +139,10 @@ See [Pyluos](/docs/tools/pyluos) documentation for more information.
 
 :::
 
-## Test your skills
-
-<Form id="liwXPLYs" />
-
-## Next steps
+## 4. Next steps
 
 With your development environment installed in Part 1, you have now taken the control of a Luos app running on your MCU, with Python. The [next part](/tutorials/get-started/get-started3) of this section deals with creating your first Luos network.
+
+## 5. Test your skills
+
+<Form id="liwXPLYs" />

--- a/tutorials/get-started/get-started3.mdx
+++ b/tutorials/get-started/get-started3.mdx
@@ -285,14 +285,11 @@ device.led.state=False
 device.blinker.play()
 ```
 
-## Next steps
+## 5. Next steps
 
-:::info
 In this Get started tutorial, we used the default network used by Luos engine called Robus. The customization of your physical interface will be addressed in a future tutorial. The default hardware interface used by Robus is defined on the <a href="https://github.com/Luos-io/luos_engine/tree/main/network/robus/HAL" target="_blank" rel="external nofollow">Robus HAL</a> folder corresponding to your device.
 
-:::
-
-## Test your skills
+## 6. Test your skills
 
 <Form id="FV0qhGbo" />
 

--- a/tutorials/get-started/get-started4.mdx
+++ b/tutorials/get-started/get-started4.mdx
@@ -211,14 +211,14 @@ Now unplug the USB cable of Board 1 and connect the USB cable of board 2. Then f
   />
 </div>
 
-## Test your skills
-
-<Form id="xliTcdZx" />
-
-## Conclusion
+## 5. Conclusion
 
 **Congratulation, you succeed to visualize your network on the _Luos Network Display_ tool!**
 
 You can check out our [tutorials](/tutorials) in our Academy section to learn more about Luos and understand how to use the features of Luos technology. We also invite you to check out our [documentation](/docs/luos-technology) to learn more about the core concepts of Luos.
 
 ⭐ If you liked this tutorial, feel free to star our <a href="https://github.com/Luos-io/luos_engine" target="_blank" rel="external nofollow">Luos engine repository</a>⭐
+
+## 6. Test your skills
+
+<Form id="xliTcdZx" />

--- a/tutorials/your-first-detection/embedded-app.mdx
+++ b/tutorials/your-first-detection/embedded-app.mdx
@@ -423,6 +423,6 @@ Now try to move your switcher package on another board, and keep the button and 
 
 Asking the value of the button every 10ms represents a not negligible portion of code. Luos engine provides an `update_time` command to simplify it, check the [documentation associated page](/docs/luos-technology/message/advanced-message) to learn more about it.
 
-## Test your skills
+## 8. Test your skills
 
 <Form id="RafOVrdv" />

--- a/tutorials/your-first-message/send-message.mdx
+++ b/tutorials/your-first-message/send-message.mdx
@@ -289,6 +289,6 @@ Let's try a small exercise:
   />
 </div>
 
-## Test your skills
+## 7. Test your skills
 
 <Form id="E28leTg2" />

--- a/tutorials/your-first-service/create-a-package.mdx
+++ b/tutorials/your-first-service/create-a-package.mdx
@@ -282,6 +282,6 @@ Then, use `pyluos-shell` to make a detection and you should see the following ro
 
 Now try to move your led package on another board. Keep only the led package on this second board, and keep the pipe, the gate, and the blinker into the first one. Then wire a OneWire network as you learned in [Part 3 in the _Get started_](/tutorials/get-started/get-started3).
 
-## Test your skills
+## 6. Test your skills
 
 <Form id="G0c9xCMX" />


### PR DESCRIPTION
…page with a quiz

⚠ PLEASE DO NOT DELETE THE TEXT BELOW ⚠

## Pull request's description

*Add here a description of the modifications you made.*

## Checklist before merging (please do not edit)
You must review you work before to submit the review to others.

### Self-review of your content
Remember the content must be readable and understandable by someone else than yourself.
- [x] From a technical point of view.
- [x] From a grammatical point of view (spelling mistakes, typos, clarity, etc.), and following the guidelines at the bottom.

### External reviews of your content
- [x] You requested a technical review.
- [x] You requested a grammatical review.
- [ ] You validated with @K0rdan or @alexgeron-Luos that it is safe to merge.

### Some guidelines to keep in mind
- Colons (:), semi-colons (;), exclamation (!), and interrogation points (?) are not preceded by a space (like full stops and commas). E.g.: Colons!
- File names and/or address are put in *italic*. E.g.: The file _main.c_.
- Functions, variables, or more generally short codes are put between grave accents. E.g.: To obtain `code()`, type \`code()\`.
- Long codes are put into blocks of code with three grave accent on each side, and the language's name:<br />
\`\`\`c<br />
// Some C language <br />
\`\`\`<br />

- "Luos engine" has a upper case on the **L** for "Luos" and lower case on the **e** for "engine".
- We call it "Luos engine" as a proper name, and ***not*** "the Luos engine".
- Following that fashion, anything that's owned by "Luos engine" implies that we must use `'s` as the standard English rule to show the possessive case, e.g. "Luos engine's API".
- The names pipe, gate, inspector, sniffer, app or application, driver, etc. have a lower case and can be refereed with the determiner `the`. E.g.: The inspector.
