### PR TITLE
Fix content to lowercase to be URL compliant, only the UI display sho…

### DIFF
--- a/src/components/school/index/data/dataIntro.json
+++ b/src/components/school/index/data/dataIntro.json
@@ -8,14 +8,13 @@
       { "id": 3, "label": "Less than 6 hours", "duration": 360 },
       { "id": 4, "label": "More than 6 hours", "duration": 361 }
     ],
-    "hardware": ["arduino", "l0", "nucleo"],
-    "category": ["Tutorials", "Trainings", "Codelab", "Use Case"]
+    "category": ["tutorials", "trainings", "Codelab", "use case"]
   },
   "tuto": [
     {
       "title": "Get Started",
       "id": "get-started",
-      "category": "Trainings",
+      "category": "trainings",
       "toc": 60,
       "level": 1,
       "img": "Get_Started_Luos",
@@ -27,7 +26,7 @@
     {
       "title": "Your First Service",
       "id": "your-first-service",
-      "category": "Trainings",
+      "category": "trainings",
       "toc": 60,
       "level": 2,
       "img": "Your_first_service_Luos",
@@ -39,7 +38,7 @@
     {
       "title": "Your First Message",
       "id": "your-first-message",
-      "category": "Trainings",
+      "category": "trainings",
       "toc": 60,
       "level": 2,
       "img": "Your_first_message_Luos",
@@ -51,7 +50,7 @@
     {
       "title": "Your First Topology detection",
       "id": "your-first-detection",
-      "category": "Trainings",
+      "category": "trainings",
       "toc": 60,
       "level": 3,
       "img": "Your_First_Topology_detection_Luos",
@@ -63,7 +62,7 @@
     {
       "title": "Luos with Arduino IDE",
       "id": "arduino",
-      "category": "Tutorials",
+      "category": "tutorials",
       "toc": 30,
       "level": 2,
       "img": "Luos_and_Arduino",
@@ -75,7 +74,7 @@
     {
       "title": "Bootloader",
       "id": "bootloader",
-      "category": "Tutorials",
+      "category": "tutorials",
       "toc": 30,
       "level": 2,
       "img": "Bootloader_Luos",
@@ -87,7 +86,7 @@
     {
       "title": "How to use Luos with FreeRTOS",
       "id": "freertos",
-      "category": "Tutorials",
+      "category": "tutorials",
       "toc": 30,
       "level": 2,
       "img": "Luos_and_FreeRTOS",
@@ -99,7 +98,7 @@
     {
       "title": "How to have flexible and resilient aliases",
       "id": "resilient-alias",
-      "category": "Tutorials",
+      "category": "tutorials",
       "toc": 30,
       "level": 2,
       "img": "Alias-Luos",
@@ -111,7 +110,7 @@
     {
       "title": "Develop a connected bike alarm",
       "id": "bike-alarm",
-      "category": "Tutorials",
+      "category": "tutorials",
       "toc": 120,
       "level": 3,
       "img": "Bike_Alarm",
@@ -131,7 +130,7 @@
     {
       "title": "Create Luos project with PlatformIo",
       "id": "pio",
-      "category": "Tutorials",
+      "category": "tutorials",
       "toc": 30,
       "level": 1,
       "img": "Luos_and_PlatformIO",
@@ -143,7 +142,7 @@
     {
       "title": "How to make a Morse Encoder",
       "id": "morse",
-      "category": "Tutorials",
+      "category": "tutorials",
       "toc": 60,
       "level": 2,
       "img": "Morse_encoder_Luos",
@@ -155,7 +154,7 @@
     {
       "title": "Luos with ESP32: ESP IDF and Espressif IDE Setup",
       "id": "esp",
-      "category": "Tutorials",
+      "category": "tutorials",
       "toc": 60,
       "level": 2,
       "img": "Luos_and_ESP32",

--- a/src/components/school/index/intro.js
+++ b/src/components/school/index/intro.js
@@ -23,7 +23,6 @@ const Intro = () => {
   let defaultFilters = {
       toc: '',
       tags: [],
-      hardware: '',
       category: '',
       level: '',
     },
@@ -147,26 +146,6 @@ const Intro = () => {
               </Select>
             </FormControl>
             <FormControl sx={{ m: 1, minWidth: 120 }} size="small">
-              <InputLabel id="hardware-label" className={styles.select}>
-                Hardware
-              </InputLabel>
-              <Select
-                value={filters.hardware}
-                label="Hardware"
-                labelId="hardware-label"
-                onChange={(e) => {
-                  handleFilter(e.target.value, 'hardware');
-                }}
-              >
-                <MenuItem value="">All</MenuItem>
-                {data.filters.hardware.map((label, index) => (
-                  <MenuItem value={label} key={index}>
-                    {label}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-            <FormControl sx={{ m: 1, minWidth: 120 }} size="small">
               <InputLabel id="category-label" className={styles.select}>
                 Category
               </InputLabel>
@@ -181,7 +160,7 @@ const Intro = () => {
                 <MenuItem value="">All</MenuItem>
                 {data.filters.category.map((label, index) => (
                   <MenuItem value={label} key={index}>
-                    {label}
+                    {label.charAt(0).toUpperCase() + label.slice(1)}
                   </MenuItem>
                 ))}
               </Select>


### PR DESCRIPTION
…w the first letter uppercased

⚠ PLEASE DO NOT DELETE THE TEXT BELOW ⚠

## Pull request's description

*Add here a description of the modifications you made.*

## Checklist before merging (please do not edit)
You must review you work before to submit the review to others.

### Self-review of your content
Remember the content must be readable and understandable by someone else than yourself.
- [ ] From a technical point of view.
- [ ] From a grammatical point of view (spelling mistakes, typos, clarity, etc.), and following the guidelines at the bottom.

### External reviews of your content
- [ ] You requested a technical review.
- [ ] You requested a grammatical review.
- [ ] You validated with @K0rdan or @alexgeron-Luos that it is safe to merge.

### Some guidelines to keep in mind
- Colons (:), semi-colons (;), exclamation (!), and interrogation points (?) are not preceded by a space (like full stops and commas). E.g.: Colons!
- File names and/or address are put in *italic*. E.g.: The file _main.c_.
- Functions, variables, or more generally short codes are put between grave accents. E.g.: To obtain `code()`, type \`code()\`.
- Long codes are put into blocks of code with three grave accent on each side, and the language's name:<br />
\`\`\`c<br />
// Some C language <br />
\`\`\`<br />

- "Luos engine" has a upper case on the **L** for "Luos" and lower case on the **e** for "engine".
- We call it "Luos engine" as a proper name, and ***not*** "the Luos engine".
- Following that fashion, anything that's owned by "Luos engine" implies that we must use `'s` as the standard English rule to show the possessive case, e.g. "Luos engine's API".
- The names pipe, gate, inspector, sniffer, app or application, driver, etc. have a lower case and can be refereed with the determiner `the`. E.g.: The inspector.
