### PR TITLE
change serviceID and statistic

### DIFF
--- a/docs/luos-technology/message/advanced-message.mdx
+++ b/docs/luos-technology/message/advanced-message.mdx
@@ -20,7 +20,7 @@ For example, here is how to send a picture:
 // fill the large message info
 msg_t msg;
 color_t picture[300*300] = {/*Your favorite cat picture data*/};
-msg.header.target_mode = ID_ACK;
+msg.header.target_mode = SERVICEIDACK;
 msg.header.target = 12;
 msg.header.cmd = COLOR;
 Luos_SendData(service, &msg, picture, sizeof(color_t)*300*300);
@@ -54,7 +54,7 @@ For example, to update a service each 10 ms:
 time_luos_t time = TimeOD_TimeFrom_ms(10);
 msg_t msg;
 msg.header.target = id;
-msg.header.target_mode = IDACK;
+msg.header.target_mode = SERVICEIDACK;
 TimeOD_TimeToMsg(&time, &msg);
 msg.header.cmd = UPDATE_PUB;
 Luos_SendMsg(app, &msg);
@@ -182,7 +182,7 @@ void Motor_MsgHandler(service_t *service, msg_t *msg) {
    // check message command
    if (msg->header.cmd == ASK_PUB_CMD) {
        // prepare a reply message and send
-       pub_msg.header.target_mode = ID;
+       pub_msg.header.target_mode = SERVICEID;
        pub_msg.header.target = msg->header.source;
        pub_msg.header.cmd = ANGULAR_POSITION;
        Luos_SendStreaming(service, &pub_msg, &measurement);

--- a/docs/luos-technology/message/basic-message.mdx
+++ b/docs/luos-technology/message/basic-message.mdx
@@ -18,7 +18,7 @@ To send a message, you have to:
 
 // Create and fill the message info
 msg_t pub_msg;
-pub_msg.header.target_mode = ID;
+pub_msg.header.target_mode = SERVICEID;
 pub_msg.header.target      = msg->header.source;
 pub_msg.header.cmd         = IO_STATE;
 pub_msg.header.size        = sizeof(char);

--- a/docs/luos-technology/message/handling-message.mdx
+++ b/docs/luos-technology/message/handling-message.mdx
@@ -36,7 +36,7 @@ void Button_MsgHandler(service_t *service, msg_t *msg)
         // The message is filled with global variables with proper data
         msg_t pub_msg;
         pub_msg.header.cmd         = IO_STATE;
-        pub_msg.header.target_mode = ID;
+        pub_msg.header.target_mode = SERVICEID;
         pub_msg.header.target      = msg->header.source;
         pub_msg.header.size        = sizeof(char);
         pub_msg.data[0]            = HAL_GPIO_ReadPin(BTN_GPIO_Port, BTN_Pin);
@@ -82,7 +82,7 @@ void Button_Loop(void)
             // The message is filled with global variables with proper data
             msg_t pub_msg;
             pub_msg.header.cmd         = IO_STATE;
-            pub_msg.header.target_mode = ID;
+            pub_msg.header.target_mode = SERVICEID;
             pub_msg.header.target      = msg->header.source;
             pub_msg.header.size        = sizeof(char);
             pub_msg.data[0]            = HAL_GPIO_ReadPin(BTN_GPIO_Port, BTN_Pin);

--- a/docs/luos-technology/message/message.mdx
+++ b/docs/luos-technology/message/message.mdx
@@ -46,8 +46,8 @@ typedef struct{
 - **Protocol (4 bits)**: This field provides the protocol revision. This field is automatically filled; you don't have to deal with it.
 - **Target (12 bits)**: This field contains the target address. To understand the real destination of this field, you have to know the addressing mode contained on the _Target_mode_ field.
 - **Target_mode (4 bits)**: This field indicates the addressing mode and how to understand the _Target_ field. It can take different values:
-  - **ID**: This mode allows to communicate with a unique service using its ID **without** acknowledgment return.
-  - **IDACK**: This mode allows to communicate with a unique service using its ID **with** acknowledgment return.
+  - **SERVICEID**: This mode allows to communicate with a unique service using its ID **without** acknowledgment return.
+  - **SERVICEIDACK**: This mode allows to communicate with a unique service using its ID **with** acknowledgment return.
   - **TYPE**: This mode sends a message to all services with a given type, e.g. all "Sharp digital distance sensor".
   - **BROADCAST**: This mode allows all the services in the network to catch a message. In this case, the message contains a type of data used by multiple services.
   - **TOPIC**: Publisher/Subscriber mode, allows multiple services to catch a message depending on the topic that they subscribed to.

--- a/docs/tools/monitoring.mdx
+++ b/docs/tools/monitoring.mdx
@@ -19,9 +19,9 @@ Finding, understanding, and managing bugs on multiple boards running multiple se
 
 ## Service exclusion
 
-Luos engine includes an acknowledgment management using the `ID_ACK` target_mode. This mode guarantees the proper reception of critical messages.
+Luos engine includes an acknowledgment management using the `SERVICEIDACK` target_mode. This mode guarantees the proper reception of critical messages.
 
-If Luos fails to reach its target using ID_ACK, it will retry 10 times. If the acknowledgment still fails, the targeted service is declared excluded. Excluded services are removed from the routing table to avoid messaging from any services, preserving bandwidth for the rest of the system.
+If Luos fails to reach its target using SERVICEIDACK, it will retry 10 times. If the acknowledgment still fails, the targeted service is declared excluded. Excluded services are removed from the routing table to avoid messaging from any services, preserving bandwidth for the rest of the system.
 
 :::note
 - Gates services can report service exclusion through JSON.
@@ -44,7 +44,7 @@ This structure gives you access to several values:
 
 - `memory`: Memory statisctics information.
 - `rx_msg_stack_ratio`: Percentage of memory occupation of Rx message management tasks.
-- `luos_stack_ratio`: Percentage of memory occupation of Luos engine's tasks.
+- `engine_msg_stack_ratio`: Percentage of memory occupation of Luos engine's tasks.
 - `tx_msg_stack_ratio`: Percentage of memory occupation of Tx message management tasks.
 - `buffer_occupation_ratio`: Percentage of memory occupation of the message buffer.
 - `msg_drop_number`: Number of messages dropped due to a lack of memory (older messages are dropped to be replaced by new ones).


### PR DESCRIPTION
⚠ PLEASE DO NOT DELETE THE TEXT BELOW ⚠

## Pull request's description

*Add here a description of the modifications you made.*

## Checklist before merging (please do not edit)
You must review you work before to submit the review to others.

### Self-review of your content
Remember the content must be readable and understandable by someone else than yourself.
- [ ] From a technical point of view.
- [ ] From a grammatical point of view (spelling mistakes, typos, clarity, etc.), and following the guidelines at the bottom.

### External reviews of your content
- [ ] You requested a technical review.
- [x] You requested a grammatical review.
- [ ] You validated with @K0rdan or @alexgeron-Luos that it is safe to merge.

### Some guidelines to keep in mind
- Colons (:), semi-colons (;), exclamation (!), and interrogation points (?) are not preceded by a space (like full stops and commas). E.g.: Colons!
- File names and/or address are put in *italic*. E.g.: The file _main.c_.
- Functions, variables, or more generally short codes are put between grave accents. E.g.: To obtain `code()`, type \`code()\`.
- Long codes are put into blocks of code with three grave accent on each side, and the language's name:<br />
\`\`\`c<br />
// Some C language <br />
\`\`\`<br />

- "Luos engine" has a upper case on the **L** for "Luos" and lower case on the **e** for "engine".
- We call it "Luos engine" as a proper name, and ***not*** "the Luos engine".
- Following that fashion, anything that's owned by "Luos engine" implies that we must use `'s` as the standard English rule to show the possessive case, e.g. "Luos engine's API".
- The names pipe, gate, inspector, sniffer, app or application, driver, etc. have a lower case and can be refereed with the determiner `the`. E.g.: The inspector.
