### PR TITLE
SEO improvements following semrush

### DIFF
--- a/blog/2022-08-12-how-to-develop-iot-edge-and-embedded-projects-easier.mdx
+++ b/blog/2022-08-12-how-to-develop-iot-edge-and-embedded-projects-easier.mdx
@@ -47,6 +47,7 @@ Aerospace is a passion for many Luos developers and the cross-over was relevant.
   <tr border="0">
     <td border="0">
       <img
+        alt="Nosecone mold of our rocket"
         desc="Nosecone mold of our rocket"
         src="/assets/images/blog/Nosecone_mold_of_our_rocket_Luos.jpeg"
       />
@@ -54,6 +55,7 @@ Aerospace is a passion for many Luos developers and the cross-over was relevant.
     </td>
     <td border="0">
       <img
+        alt="Representation of our rocket"
         desc="Representation of our rocket"
         src="/assets/images/blog/Representation-of-our-rocket-Luos.png"
       />

--- a/docs/tools/platformio.mdx
+++ b/docs/tools/platformio.mdx
@@ -1,6 +1,6 @@
 ---
 custom_edit_url: null
-description: The gate is a major tool of the Luos ecosystem.
+description: With PlatformIO, Luos libraries use scripts before compilation to select and include the code folder depending to your needs.
 ---
 
 import Tooltip from '@site/src/components/Tooltip.js';

--- a/faq/001.detection-reconfig.mdx
+++ b/faq/001.detection-reconfig.mdx
@@ -1,5 +1,6 @@
 ---
 custom_edit_url: null
+description: An application can auto-update a data from a driver in a Luos system.
 ---
 
 # Using a gate on my device seems to stop the normal behavior

--- a/faq/002.dfu.mdx
+++ b/faq/002.dfu.mdx
@@ -1,5 +1,6 @@
 ---
 custom_edit_url: null
+description: When you try to update a board using DFU or STLink, an error message appears on PlatformiO.
 ---
 
 import Image from '@site/src/components/Image';

--- a/faq/003.application-does-not-compile.mdx
+++ b/faq/003.application-does-not-compile.mdx
@@ -1,5 +1,6 @@
 ---
 custom_edit_url: null
+description: Luos engine provides examples for different MCUs, and a HAL for MCU families.
 ---
 
 # The default Luos engine's examples does not compile

--- a/faq/004.application-default-handler.mdx
+++ b/faq/004.application-default-handler.mdx
@@ -1,5 +1,6 @@
 ---
 custom_edit_url: null
+description: When you run a detection by adding a gate to your network or from your application, your board crashes.
 ---
 
 import { customFields } from '/docusaurus.config.js';

--- a/faq/005.stlink.mdx
+++ b/faq/005.stlink.mdx
@@ -1,5 +1,6 @@
 ---
 custom_edit_url: null
+description: When you try to update a card using ST-Link, an error message may appear on PlatformIO.
 ---
 
 import Image from '@site/src/components/Image';

--- a/faq/006.install-development-environment.mdx
+++ b/faq/006.install-development-environment.mdx
@@ -1,5 +1,6 @@
 ---
 custom_edit_url: null
+description: When you start your first application or follow the Luos's Get started, you may face problems with the environment development installation.
 ---
 
 import Image from '@site/src/components/Image.js';

--- a/faq/007.board-not-detected-network.mdx
+++ b/faq/007.board-not-detected-network.mdx
@@ -1,5 +1,6 @@
 ---
 custom_edit_url: null
+description: After flashing a board with PlatformIO and launching a detection, the board is not detected in the Luos network.
 ---
 
 import Image from '@site/src/components/Image';

--- a/faq/008.stlink_bootbug.mdx
+++ b/faq/008.stlink_bootbug.mdx
@@ -1,5 +1,6 @@
 ---
 custom_edit_url: null
+description: When you try to update a Luos board using the bootloader in a network connected with your computer using ST-Link, the process fails.
 ---
 
 import Image from '@site/src/components/Image';

--- a/faq/009.upload_arduino_bug.mdx
+++ b/faq/009.upload_arduino_bug.mdx
@@ -1,5 +1,6 @@
 ---
 custom_edit_url: null
+description: When you try to update an Arduino board, an error message may appear in the file _platformio.ini_.
 ---
 
 import Image from '@site/src/components/Image';

--- a/faq/999.add-issue.mdx
+++ b/faq/999.add-issue.mdx
@@ -1,5 +1,6 @@
 ---
 custom_edit_url: null
+description: If you encounter an issue that should appear in the FAQ, you can describe it here.
 ---
 
 import IconExternalLink from '@theme/Icon/ExternalLink';

--- a/tutorials/bike-alarm/basic-alarm.mdx
+++ b/tutorials/bike-alarm/basic-alarm.mdx
@@ -1,6 +1,7 @@
 ---
 custom_edit_url: null
 image: /assets/images/Bike-alarm-Luos.png
+description: The purpose of the bike alarm is to create an alarm that continuously measures the movements of a bike.
 ---
 
 import Image from '@site/src/components/Image';

--- a/tutorials/index.mdx
+++ b/tutorials/index.mdx
@@ -3,6 +3,7 @@ hide_title: true
 hide_table_of_contents: true
 custom_edit_url: null
 title: 'Tutorials'
+description: Here you will find all our trainings, tutorials and use cases that will help you deepen your understanding and skills on Luos.
 ---
 
 import Intro from '/src/components/school/index/intro.js';

--- a/tutorials/integrations.mdx
+++ b/tutorials/integrations.mdx
@@ -3,6 +3,7 @@ hide_title: true
 hide_table_of_contents: true
 custom_edit_url: null
 title: 'Integrations'
+description: All the Luos integrations and their tutorials to get you started and control your embedded system.
 ---
 
 import Intro from '/src/components/school/index/intro.js';

--- a/tutorials/morse/add-service.mdx
+++ b/tutorials/morse/add-service.mdx
@@ -1,6 +1,7 @@
 ---
 custom_edit_url: null
 image: /assets/images/Morse_encoder_Luos.png
+description: Now is the time to encode your own words to communicate in Morse code!
 ---
 
 import Image from '@site/src/components/Image';

--- a/tutorials/morse/algorithm.mdx
+++ b/tutorials/morse/algorithm.mdx
@@ -1,6 +1,7 @@
 ---
 custom_edit_url: null
 image: /assets/images/Morse_encoder_Luos.png
+description: The first step of this tutorial is to create the application service that will encode words into Morse signals.
 ---
 
 import Image from '@site/src/components/Image';

--- a/tutorials/morse/output.mdx
+++ b/tutorials/morse/output.mdx
@@ -1,6 +1,7 @@
 ---
 custom_edit_url: null
 image: /assets/images/Morse_encoder_Luos.png
+description: After we have created our Morse encoder application, we need to integrate a service that will exploit the output of the Morse encoder.
 ---
 
 import Image from '@site/src/components/Image';

--- a/tutorials/pio/creation.mdx
+++ b/tutorials/pio/creation.mdx
@@ -1,5 +1,6 @@
 ---
 custom_edit_url: null
+description: We will guide you through the process! You will learn how to set up a PlatformIO environment and how to make a good project structure.
 ---
 
 import Image from '@site/src/components/Image';

--- a/tutorials/pio/include.mdx
+++ b/tutorials/pio/include.mdx
@@ -1,5 +1,6 @@
 ---
 custom_edit_url: null
+description: The file _platformio.ini_ in your project describes the precompiler variables and the library depencies of your project.
 ---
 
 import Image from '@site/src/components/Image';

--- a/tutorials/trainings.mdx
+++ b/tutorials/trainings.mdx
@@ -3,6 +3,7 @@ hide_title: true
 hide_table_of_contents: true
 custom_edit_url: null
 title: 'Trainings'
+description: All the Luos training to get started, create your first Luos service, send your first message, launch a detection and much more.
 ---
 
 import Intro from '/src/components/school/index/intro.js';

--- a/tutorials/usecases.mdx
+++ b/tutorials/usecases.mdx
@@ -3,6 +3,7 @@ hide_title: true
 hide_table_of_contents: true
 custom_edit_url: null
 title: 'Use cases'
+description: To quickly see the benefits of Luos, many use cases are available. They will allow you to have projects led by developers and the Luos community.
 ---
 
 import Intro from '/src/components/school/index/intro.js';

--- a/tutorials/your-first-detection/embedded-app.mdx
+++ b/tutorials/your-first-detection/embedded-app.mdx
@@ -1,6 +1,7 @@
 ---
 custom_edit_url: null
 image: /assets/images/Your-first-topology-detection-banner-luos.png
+description: Let's code that and see how cool it is to do it with Luos engine!
 ---
 
 import Image from '@site/src/components/Image';

--- a/tutorials/your-first-detection/routing-table.mdx
+++ b/tutorials/your-first-detection/routing-table.mdx
@@ -1,6 +1,7 @@
 ---
 custom_edit_url: null
 image: /assets/images/Your-first-topology-detection-banner-luos.png
+description: You just learned how to detect a Luos engine network.
 ---
 
 import Image from '@site/src/components/Image';

--- a/tutorials/your-first-detection/topology.mdx
+++ b/tutorials/your-first-detection/topology.mdx
@@ -1,6 +1,7 @@
 ---
 custom_edit_url: null
 image: /assets/images/Your-first-topology-detection-banner-luos.png
+description: In the previous training, we created a LED and a button services to control them using Pyluos.
 ---
 
 import Image from '@site/src/components/Image';

--- a/tutorials/your-first-detection/your-first-detection.mdx
+++ b/tutorials/your-first-detection/your-first-detection.mdx
@@ -24,7 +24,7 @@ import Introduction from '@site/src/components/school/article/intro.js';
     },
     {
       label: 'Luos Basics',
-      link: 'luos-technology/basics',
+      link: '/docs/luos-technology/basics',
     },
     {
       label: 'Your first service tutorial',

--- a/tutorials/your-first-message/receiving-message.mdx
+++ b/tutorials/your-first-message/receiving-message.mdx
@@ -1,6 +1,7 @@
 ---
 custom_edit_url: null
 image: /assets/images/tutorials/your-first-message-banner-luos.png
+description: A button can be represented (as a LED) by a state-type service.
 ---
 
 import Image from '@site/src/components/Image';

--- a/tutorials/your-first-message/send-message.mdx
+++ b/tutorials/your-first-message/send-message.mdx
@@ -1,6 +1,7 @@
 ---
 custom_edit_url: null
 image: /assets/images/tutorials/your-first-message-banner-luos.png
+description: There are two ways to receive a message, but what about sending one?
 ---
 
 import Image from '@site/src/components/Image';

--- a/tutorials/your-first-service/create-a-package.mdx
+++ b/tutorials/your-first-service/create-a-package.mdx
@@ -1,6 +1,7 @@
 ---
 custom_edit_url: null
 image: /assets/images/tutorials/your-first-service-banner-luos.png
+description: If we want to be able to easily move our led service from one project to another, read this tutorial.
 ---
 
 import Image from '@site/src/components/Image';

--- a/tutorials/your-first-service/luos-service.mdx
+++ b/tutorials/your-first-service/luos-service.mdx
@@ -1,6 +1,7 @@
 ---
 custom_edit_url: null
 image: /assets/images/tutorials/your-first-service-banner-luos.png
+description: In the Get started tutorial, we learned to perform the following essential actions
 ---
 
 import Image from '@site/src/components/Image';

--- a/versioned_docs/version-2.6.0/tools/platformio.mdx
+++ b/versioned_docs/version-2.6.0/tools/platformio.mdx
@@ -1,6 +1,6 @@
 ---
 custom_edit_url: null
-description: The gate is a major tool of the Luos ecosystem.
+description: With PlatformIO, Luos libraries use scripts before compilation to select and include the code folder depending to your needs.
 ---
 
 import Tooltip from '@site/src/components/Tooltip.js';


### PR DESCRIPTION
⚠ PLEASE DO NOT DELETE THE TEXT BELOW ⚠

## Pull request's description

After the SEO improvements of the content platform were put into production, some errors were still present. This PR solves them.

## Checklist before merging (please do not edit)
You must review you work before to submit the review to others.

### Self-review of your content
Remember the content must be readable and understandable by someone else than yourself.
- [x] From a technical point of view.
- [x] From a grammatical point of view (spelling mistakes, typos, clarity, etc.), and following the guidelines at the bottom.

### External reviews of your content
- [ ] You requested a technical review.
- [ ] You requested a grammatical review.
- [ ] You validated with @K0rdan or @alexgeron-Luos that it is safe to merge.

### Some guidelines to keep in mind
- Colons (:), semi-colons (;), exclamation (!), and interrogation points (?) are not preceded by a space (like full stops and commas). E.g.: Colons!
- File names and/or address are put in *italic*. E.g.: The file _main.c_.
- Functions, variables, or more generally short codes are put between grave accents. E.g.: To obtain `code()`, type \`code()\`.
- Long codes are put into blocks of code with three grave accent on each side, and the language's name:<br />
\`\`\`c<br />
// Some C language <br />
\`\`\`<br />

- "Luos engine" has a upper case on the **L** for "Luos" and lower case on the **e** for "engine".
- We call it "Luos engine" as a proper name, and ***not*** "the Luos engine".
- Following that fashion, anything that's owned by "Luos engine" implies that we must use `'s` as the standard English rule to show the possessive case, e.g. "Luos engine's API".
- The names pipe, gate, inspector, sniffer, app or application, driver, etc. have a lower case and can be refereed with the determiner `the`. E.g.: The inspector.
