### PR TITLE
Modify coming soon description

### DIFF
--- a/docs/integrations/index.mdx
+++ b/docs/integrations/index.mdx
@@ -9,10 +9,10 @@ Luos provides many tools to interface, control, or monitor products made with Lu
 
 |                        Tools                        | Description |
 | :-------------------------------------------------: | :---------: |
-|         [SDK python: Pyluos](./pyluos.mdx)          | Coming soon |
-| [SDK typescript](https://github.com/Luos-io/sdk-ts) | Coming soon |
-|            [PlatformIO](/tutorials/pio)             | Coming soon |
-|          [Arduino IDE](/tutorials/arduino)          | Coming soon |
-|           [Espressif IDE](/tutorials/esp)           | Coming soon |
-|             [RTOS](/tutorials/freertos)             | Coming soon |
-|                [ROS 1&2](./ros.mdx)                 | Coming soon |
+|         [SDK python: Pyluos](./pyluos.mdx)          | Pyluos is the standard Python library to manage a Luos system with a computer. |
+| [SDK typescript](https://github.com/Luos-io/sdk-ts) | A Typescript library to program a Luos based network through a high level interface. |
+|            [PlatformIO](/tutorials/pio)             | Create a Luos project with PlatformIO |
+|          [Arduino IDE](/tutorials/arduino)          | Use Luos with Arduino IDE |
+|           [Espressif IDE](/tutorials/esp)           | Luos with ESP32: ESP IDF and Espressif IDE Setup |
+|             [RTOS](/tutorials/freertos)             | Use Luos with an RTOS and discover the benefits of this combination |
+|                [ROS 1&2](./ros.mdx)                 | Luos comes with a package for the Robot Operating System |

--- a/docs/tools/index.mdx
+++ b/docs/tools/index.mdx
@@ -13,9 +13,9 @@ Luos provides many tools to interface, control, or monitor products made with Lu
 |                     Tools                      |                                              Description                                              |
 | :--------------------------------------------: | :---------------------------------------------------------------------------------------------------: |
 |               [Gate](./gate.mdx)               | A translation Luos app service allowing you to easily connect your computer to your hardware product. |
-|           [Json API](./api-json.mdx)           |                                              Coming soon                                              |
+|           [Json API](./api-json.mdx)           | The JSON formatted data is common and widely used by many programming languages.                      |
 |         [Bootloader](./bootloader.mdx)         |                                   Update node through Luos network                                    |
 |          [Inspector](./inspector.mdx)          |                 A Luos service application allowing a computer to inspect a product.                  |
 |         [Monitoring](./monitoring.mdx)         |                             API that allows you to monitor a Luos network                             |
 |         [PlatformIO](./platformio.mdx)         |                                How to configure Luos with PlatformIO.                                 |
-| [Network display](https://app.luos.io/network) |                                              Coming soon                                              |
+| [Network display](https://app.luos.io/network) |                 With this tool, you will find your system represented by nodes and services           |

--- a/sidebarsDocs.js
+++ b/sidebarsDocs.js
@@ -230,7 +230,7 @@ module.exports = {
         },
         {
           type: 'link',
-          label: 'PlateformIO',
+          label: 'PlatformIO',
           href: 'https://www.luos.io/tutorials/pio',
         },
         {

--- a/versioned_docs/version-2.6.0/integrations/index.mdx
+++ b/versioned_docs/version-2.6.0/integrations/index.mdx
@@ -9,10 +9,10 @@ Luos provides many tools to interface, control, or monitor products made with Lu
 
 |                        Tools                        | Description |
 | :-------------------------------------------------: | :---------: |
-|         [SDK python: Pyluos](./pyluos.mdx)          | Coming soon |
-| [SDK typescript](https://github.com/Luos-io/sdk-ts) | Coming soon |
-|            [PlatformIO](/tutorials/pio)             | Coming soon |
-|          [Arduino IDE](/tutorials/arduino)          | Coming soon |
-|           [Espressif IDE](/tutorials/esp)           | Coming soon |
-|             [RTOS](/tutorials/freertos)             | Coming soon |
-|                [ROS 1&2](./ros.mdx)                 | Coming soon |
+|         [SDK python: Pyluos](./pyluos.mdx)          | Pyluos is the standard Python library to manage a Luos system with a computer. |
+| [SDK typescript](https://github.com/Luos-io/sdk-ts) | A Typescript library to program a Luos based network through a high level interface. |
+|            [PlatformIO](/tutorials/pio)             | Create a Luos project with PlatformIO |
+|          [Arduino IDE](/tutorials/arduino)          | Use Luos with Arduino IDE |
+|           [Espressif IDE](/tutorials/esp)           | Luos with ESP32: ESP IDF and Espressif IDE Setup |
+|             [RTOS](/tutorials/freertos)             | Use Luos with an RTOS and discover the benefits of this combination |
+|                [ROS 1&2](./ros.mdx)                 | Luos comes with a package for the Robot Operating System |

--- a/versioned_docs/version-2.6.0/tools/index.mdx
+++ b/versioned_docs/version-2.6.0/tools/index.mdx
@@ -13,9 +13,9 @@ Luos provides many tools to interface, control, or monitor products made with Lu
 |                     Tools                      |                                              Description                                              |
 | :--------------------------------------------: | :---------------------------------------------------------------------------------------------------: |
 |               [Gate](./gate.mdx)               | A translation Luos app service allowing you to easily connect your computer to your hardware product. |
-|           [Json API](./api-json.mdx)           |                                              Coming soon                                              |
+|           [Json API](./api-json.mdx)           | The JSON formatted data is common and widely used by many programming languages.                      |
 |         [Bootloader](./bootloader.mdx)         |                                   Update node through Luos network                                    |
 |          [Inspector](./inspector.mdx)          |                 A Luos service application allowing a computer to inspect a product.                  |
 |         [Monitoring](./monitoring.mdx)         |                             API that allows you to monitor a Luos network                             |
 |         [PlatformIO](./platformio.mdx)         |                                How to configure Luos with PlatformIO.                                 |
-| [Network display](https://app.luos.io/network) |                                              Coming soon                                              |
+| [Network display](https://app.luos.io/network) |          With this tool, you will find your system represented by nodes and services                  |

--- a/versioned_sidebars/version-2.6.0-sidebars.json
+++ b/versioned_sidebars/version-2.6.0-sidebars.json
@@ -230,7 +230,7 @@
         },
         {
           "type": "link",
-          "label": "PlateformIO",
+          "label": "PlatformIO",
           "href": "https://www.luos.io/tutorials/pio"
         },
         {


### PR DESCRIPTION
⚠ PLEASE DO NOT DELETE THE TEXT BELOW ⚠

## Pull request's description

Modify our 'Coming soon' description in Built-in tools and Integrations. We also add an error in the PlatformIO link.

## Checklist before merging (please do not edit)
You must review you work before to submit the review to others.

### Self-review of your content
Remember the content must be readable and understandable by someone else than yourself.
- [ ] From a technical point of view.
- [ ] From a grammatical point of view (spelling mistakes, typos, clarity, etc.), and following the guidelines at the bottom.

### External reviews of your content
- [ ] You requested a technical review.
- [ ] You requested a grammatical review.
- [ ] You validated with @K0rdan or @alexgeron-Luos that it is safe to merge.

### Some guidelines to keep in mind
- Colons (:), semi-colons (;), exclamation (!), and interrogation points (?) are not preceded by a space (like full stops and commas). E.g.: Colons!
- File names and/or address are put in *italic*. E.g.: The file _main.c_.
- Functions, variables, or more generally short codes are put between grave accents. E.g.: To obtain `code()`, type \`code()\`.
- Long codes are put into blocks of code with three grave accent on each side, and the language's name:<br />
\`\`\`c<br />
// Some C language <br />
\`\`\`<br />

- "Luos engine" has a upper case on the **L** for "Luos" and lower case on the **e** for "engine".
- We call it "Luos engine" as a proper name, and ***not*** "the Luos engine".
- Following that fashion, anything that's owned by "Luos engine" implies that we must use `'s` as the standard English rule to show the possessive case, e.g. "Luos engine's API".
- The names pipe, gate, inspector, sniffer, app or application, driver, etc. have a lower case and can be refereed with the determiner `the`. E.g.: The inspector.
