### PR TITLE
Fix/seo problems

### DIFF
--- a/src/components/index/anatomy/anatomy.js
+++ b/src/components/index/anatomy/anatomy.js
@@ -72,7 +72,7 @@ const Anatomy = (props) => {
             <ListItem
               alignitems="flex-start"
               component={Link}
-              href="/tutorials/bootloader/intro"
+              href="/tutorials/bootloader"
               className={styles.listLink}
             >
               <ListItemAvatar>

--- a/src/components/index/integration/integration.js
+++ b/src/components/index/integration/integration.js
@@ -56,7 +56,7 @@ const Integration = (props) => {
     stm: '/docs/compatibility/mcu_demoboard#st',
     microship: '/docs/compatibility/mcu_demoboard',
     raspberry: '',
-    arduino: '/tutorials/arduino/intro',
+    arduino: '/tutorials/arduino',
     pio: '/tutorials/get-started#2-set-up-your-development-environment',
     eclipse: '/docs/luos-technology/basics/organization#luos-engines-levels',
     vscodeico: '/docs/luos-technology/basics/organization#luos-engines-levels',

--- a/src/components/index/integration/integration.js
+++ b/src/components/index/integration/integration.js
@@ -57,7 +57,7 @@ const Integration = (props) => {
     microship: '/docs/compatibility/mcu_demoboard',
     raspberry: '',
     arduino: '/tutorials/arduino/intro',
-    pio: '/tutorials/get-started/get-started#2-set-up-your-development-environment',
+    pio: '/tutorials/get-started#2-set-up-your-development-environment',
     eclipse: '/docs/luos-technology/basics/organization#luos-engines-levels',
     vscodeico: '/docs/luos-technology/basics/organization#luos-engines-levels',
     ros: '/docs/integrations/ros',

--- a/src/components/school/index/data/dataIntro.json
+++ b/src/components/school/index/data/dataIntro.json
@@ -44,7 +44,7 @@
       "img": "Your_first_message_Luos",
       "desc": "Luos aim to exchange information between services by sending messages. In this tutorial we will learn the message structure and how to send it to another services.",
       "tags": ["Luos Message", "Service", "Polling", "Message Handler"],
-      "link": "your-first-message",
+      "link": "/tutorials/your-first-message",
       "author": "nicoC"
     },
     {
@@ -68,7 +68,7 @@
       "img": "Luos_and_Arduino",
       "desc": "In this tutorial, you will how to set up a Luos-Arduino project on Arduino IDE.",
       "tags": ["Board", "MCU", "Service", "Network", "Distributed System"],
-      "link": "/tutorials/arduino/intro",
+      "link": "/tutorials/arduino",
       "author": "nicoR"
     },
     {
@@ -80,7 +80,7 @@
       "img": "Bootloader_Luos",
       "desc": "In this tutorial, you will learn to use the bootloader feature offered by Luos technology.",
       "tags": ["Board", "MCU", "Service", "Network", "Distributed System"],
-      "link": "/tutorials/bootloader/intro",
+      "link": "/tutorials/bootloader",
       "author": "thomas"
     },
     {
@@ -104,7 +104,7 @@
       "img": "Alias-Luos",
       "desc": "Luos provides a flexible way to deal with aliases. In this tutorial, we discover how to configure aliases and how to make the configuration resilient to boot and flash.",
       "tags": ["Alias", "Distributed System", "Flash", "ROM", "EEPROM"],
-      "link": "/tutorials/resilient-alias/intro",
+      "link": "/tutorials/resilient-alias",
       "author": "nicoR"
     },
     {

--- a/src/pages/roadmap.mdx
+++ b/src/pages/roadmap.mdx
@@ -2,6 +2,7 @@
 hide_table_of_contents: true
 custom_edit_url: null
 title: Luos roadmap
+description: This page is a preview of Luos’s product roadmap.
 ---
 
 import Roadmap from '@site/src/components/roadmap/Roadmap';

--- a/tutorials/bootloader/bootloader.mdx
+++ b/tutorials/bootloader/bootloader.mdx
@@ -3,6 +3,7 @@ custom_edit_url: null
 hide_title: true
 title: Bootloader
 image: /assets/images/Bootloader-Luos-banner.png
+description: In this tutorial, you will learn to use the bootloader feature offered by Luos technology.
 ---
 
 import Image from '@site/src/components/Image';

--- a/tutorials/esp/esp.mdx
+++ b/tutorials/esp/esp.mdx
@@ -2,6 +2,7 @@
 custom_edit_url: null
 title: 'Luos with ESP32: ESP IDF and Espressif IDE Setup'
 hide_title: true
+description: In this tutorial, you will learn how to use a simple package button with ESP32 Family.
 ---
 
 import Image from '@site/src/components/Image';

--- a/tutorials/freertos/freertos.mdx
+++ b/tutorials/freertos/freertos.mdx
@@ -3,6 +3,7 @@ custom_edit_url: null
 title: 'How to use Luos engine with FreeRTOS'
 hide_title: true
 image: /assets/images/Luos-and-FreeRTOS-banner.png
+description: If you're used to develop your embedded system with FreeRTOS, you can leverage Luos features without changing the way you design your system.
 ---
 
 import Image from '@site/src/components/Image';

--- a/tutorials/luos-integration/install-ros2.mdx
+++ b/tutorials/luos-integration/install-ros2.mdx
@@ -3,6 +3,7 @@ title: How to use Luos engine with ROS
 hide_title: true
 custom_edit_url: null
 image: /assets/images/luos-integrations-install-ros-2-banner.png
+description: Install ROS 2 and get started with packages in a Luos project.
 ---
 
 import IconExternalLink from '@theme/Icon/ExternalLink';

--- a/tutorials/resilient-alias/resilient-alias.mdx
+++ b/tutorials/resilient-alias/resilient-alias.mdx
@@ -2,6 +2,7 @@
 custom_edit_url: null
 title: How to have flexible and resilient aliases
 hide_title: true
+description: In this tutorial, we discover how to configure aliases and how to make the configuration resilient to boot and flash.
 ---
 
 import Image from '@site/src/components/Image';

--- a/vercel.json
+++ b/vercel.json
@@ -328,6 +328,16 @@
       "statusCode": 301
     },
     {
+      "source": "/tutorials/arduino/intro",
+      "destination": "/tutorials/arduino",
+      "statusCode": 301
+    },
+    {
+      "source": "/tutorials/bootloader/intro",
+      "destination": "/tutorials/bootloader",
+      "statusCode": 301
+    },
+    {
       "source": "/tutorials/demo-boards(.*)",
       "destination": "/docs/compatibility/mcu_demoboard",
       "statusCode": 301
@@ -338,8 +348,23 @@
       "statusCode": 301
     },
     {
+      "source": "/tutorials/freertos/intro",
+      "destination": "/tutorials/freertos",
+      "statusCode": 301
+    },
+    {
       "source": "/tutorials/luos-and-tools/arduino",
-      "destination": "/tutorials/arduino/intro",
+      "destination": "/tutorials/arduino",
+      "statusCode": 301
+    },
+    {
+      "source": "/tutorials/get-started/get-started",
+      "destination": "/tutorials/get-started",
+      "statusCode": 301
+    },
+    {
+      "source": "/tutorials/resilient-alias/intro",
+      "destination": "/tutorials/resilient-alias",
       "statusCode": 301
     },
     {
@@ -429,6 +454,11 @@
     {
       "source": "/tutorials/bike-alarm/basic-alarm",
       "destination": "/tutorials/bike-alarm",
+      "statusCode": 301
+    },
+    {
+      "source": "/your-first-message",
+      "destination": "/tutorials/your-first-message",
       "statusCode": 301
     },
     {


### PR DESCRIPTION
⚠ PLEASE DO NOT DELETE THE TEXT BELOW ⚠

## Pull request's description

*Add here a description of the modifications you made.*

## Checklist before merging (please do not edit)
You must review you work before to submit the review to others.

### Self-review of your content
Remember the content must be readable and understandable by someone else than yourself.
- [ ] From a technical point of view.
- [ ] From a grammatical point of view (spelling mistakes, typos, clarity, etc.), and following the guidelines at the bottom.

### External reviews of your content
- [ ] You requested a technical review.
- [ ] You requested a grammatical review.
- [ ] You validated with @K0rdan or @alexgeron-Luos that it is safe to merge.

### Some guidelines to keep in mind
- Colons (:), semi-colons (;), exclamation (!), and interrogation points (?) are not preceded by a space (like full stops and commas). E.g.: Colons!
- File names and/or address are put in *italic*. E.g.: The file _main.c_.
- Functions, variables, or more generally short codes are put between grave accents. E.g.: To obtain `code()`, type \`code()\`.
- Long codes are put into blocks of code with three grave accent on each side, and the language's name:<br />
\`\`\`c<br />
// Some C language <br />
\`\`\`<br />

- "Luos engine" has a upper case on the **L** for "Luos" and lower case on the **e** for "engine".
- We call it "Luos engine" as a proper name, and ***not*** "the Luos engine".
- Following that fashion, anything that's owned by "Luos engine" implies that we must use `'s` as the standard English rule to show the possessive case, e.g. "Luos engine's API".
- The names pipe, gate, inspector, sniffer, app or application, driver, etc. have a lower case and can be refereed with the determiner `the`. E.g.: The inspector.
