### PR TITLE
Add some redirections

### DIFF
--- a/blog/2021-12-13-bootloader.mdx
+++ b/blog/2021-12-13-bootloader.mdx
@@ -23,6 +23,6 @@ This feature is the big new one everyone has asked us for years. Now, you can co
 
 This allows you to update any board/firmware anywhere on your device without having physical access to it.
 
-[More information about bootloader](/docs/tools/gate)
+[More information about bootloader](/docs/tools/bootloader)
 
 [Get Started with Luos](/tutorials/get-started)

--- a/blog/2022-04-15-web-app-alpha-version.mdx
+++ b/blog/2022-04-15-web-app-alpha-version.mdx
@@ -89,7 +89,7 @@ As you can see in figure 1, the data is encapsulated in a “Luos Frame” descr
 
 Now that we have set up this new way to communicate with the embedded world, the next step will be to give our users all the features implemented all over the years in <a rel="external nofollow" href="https://github.com/Luos-io/luos_engine" target="_blank">Luos engine</a> from a web perspective.
 
-The first feature we decided to implement is the network topology. This feature is a graphical representation of the Luos [routing table](/docs/tools/gate).
+The first feature we decided to implement is the network topology. This feature is a graphical representation of the Luos [routing table](/docs/luos-technology/node/topology#routing-table).
 
 We first get the list of the nodes and services in our network. Then we query each service of each node to get their properties like their type (Motor, Led, Gate, ...), their firmware revision, and their memory statistics.
 

--- a/blog/2022-10-11-q-and-a-october-2022.mdx
+++ b/blog/2022-10-11-q-and-a-october-2022.mdx
@@ -76,7 +76,7 @@ Basically, you can make Luos work on your board by creating **your own hardware 
 
 <h2> What are the plan for Luos in the future? </h2>
 
-We have recently been working on a **[roadmap](https://www.luos.io/roadmap)** allowing people that are using Luos to understand what we are going to do in the future.
+We have recently been working on a **[roadmap](/roadmap)** allowing people that are using Luos to understand what we are going to do in the future.
 
 I will talk about the **different features** we plan to release. Right now, we are working on the **1.7 release** which will have some improvements in the speed of the uploading of the bootloader. 
 Perhaps you’ve already seen the <a href="https://www.linkedin.com/feed/update/urn:li:activity:6981279138040946688" rel="external nofollow">video of Viktoria</a>, she worked on a feature that multiplies the speed of the bootloader which allows you to update on the device very fast.

--- a/blog/2022-11-07-a-flexible-embedded-bootloader.mdx
+++ b/blog/2022-11-07-a-flexible-embedded-bootloader.mdx
@@ -27,7 +27,7 @@ Developing an embedded system can often present constraints that many of us are 
 
 Any embedded developer may have to develop or use a bootloader to update their project. In most cases, the bootloader is developed with regard to the boards present in the system, and this bootloader could often only be used for one board, not being compatible with other MCU brands.
 
-Each company develops its own [bootloader](https://www.luos.io/docs/tools/bootloader), the current operation is that to flash an MCU, it is necessary to connect to the card physically, use an IDE to launch the command, and update the firmware. The update is more complex in the case of several cards of different brands.
+Each company develops its own [bootloader](/docs/tools/bootloader), the current operation is that to flash an MCU, it is necessary to connect to the card physically, use an IDE to launch the command, and update the firmware. The update is more complex in the case of several cards of different brands.
 
 <h2>Part 2: Bootloaders in embedded systems: how does it work?</h2>
 
@@ -90,7 +90,7 @@ To answer the questions above, we targeted the four main needs that Luos should 
 
 We have previously mentioned what a constraint could be not to have a physical connection to each board you need to update. One of the most important functionalities is to **easily upgrade different boards** without the need to connect a programmer interface to a board. Luos bootloader is designed to work in one-entry-point distributed systems. In other words, as it is explained below, we need to connect only one MCU to the computer, that is programmed with a specific Luos application called gate, and connect our embedded network to this MCU. 
 
-Whichever your system configuration, through robust network and thanks to a [gate](https://www.luos.io/docs/tools/gate) that communicates between your computer and your embedded system, you can update a board even if it is not directly connected to your computer. 
+Whichever your system configuration, through robust network and thanks to a [gate](/docs/tools/gate) that communicates between your computer and your embedded system, you can update a board even if it is not directly connected to your computer. 
 
 The **gate** is a specific tool, that can be hosted on any board, and in combination with a **pipe** that transfers the data from a computer to the embedded network, and the opposite. It is responsible to convert this data from the format received by the computer (eg. JSON) to the embedded communication protocol (eg. the Luos communication protocol called [Robus](https://www.luos.io/docs/luos-technology/node/luos-hal#robus-hal)), and the opposite.
 
@@ -121,7 +121,7 @@ The process to update a firmware of a board using the Luos bootloader is divided
 
 **Gate and pipe**: The data sent from the computer is received by a Luos service called pipe, and the pipe streams them directly to the gate. The gate converts them to the format of the embedded communication protocol and distributes them to the bootloaders. It does exactly the same process for the opposite direction. By default, the messages coming from a computer are in JSON format and the embedded communication protocol that is used is Robus, the custom protocol proposed by Luos. 
 
-**Computer**: The computer software included in Luos Python library, called [Pyluos](https://www.luos.io/docs/integrations/pyluos), is responsible to initiate and guide all the procedure. Firstly, it commands the boards that we want to upload to be set in bootloader mode and erase the necessary space in flash memory. Then, it sends the chunks of the firmware we want to uplaod. Finally, it is responsible for checking if the process is completed with success.
+**Computer**: The computer software included in Luos Python library, called [Pyluos](/docs/integrations/pyluos), is responsible to initiate and guide all the procedure. Firstly, it commands the boards that we want to upload to be set in bootloader mode and erase the necessary space in flash memory. Then, it sends the chunks of the firmware we want to uplaod. Finally, it is responsible for checking if the process is completed with success.
 
 <h3>Speed</h3>
 
@@ -137,7 +137,7 @@ Since you are updating a set of boards through the same one, you will avoid nume
 
 The latest version of Luos bootloader includes a feature that will also help you save time, in case that your distributed system contains several boards that you need to update with the same firmware. 
 
-By using this feature, when we aim to upload the same firmware to multiple boards, the [messages](https://www.luos.io/docs/luos-technology/messages) are sent with the method publisher/subscriber, and the bootloader existing in them subscribes to a specific topic, in order to receive the binary chunks. So, each message is sent only once for all the boards, opposingly to the previous versions, where each message was sent to each board, helping us save a huge amount of time.
+By using this feature, when we aim to upload the same firmware to multiple boards, the [messages](/docs/luos-technology/messages) are sent with the method publisher/subscriber, and the bootloader existing in them subscribes to a specific topic, in order to receive the binary chunks. So, each message is sent only once for all the boards, opposingly to the previous versions, where each message was sent to each board, helping us save a huge amount of time.
 
 <div align="center">
   <Image

--- a/vercel.json
+++ b/vercel.json
@@ -29,6 +29,11 @@
       "statusCode": 301
     },
     {
+      "source": "/blog/what-is-luos-really-how-we-built-the-speech…",
+      "destination": "/blog/what-is-luos-really-how-we-built-the-speech",
+      "statusCode": 301
+    },
+    {
       "source": "/community",
       "destination": "https://discord.gg/luos"
     },
@@ -65,6 +70,11 @@
     {
       "source": "/docs/hardware-consideration/minimum-requirement",
       "destination": "/docs/hardware-consideration/minimum-requirements",
+      "statusCode": 301
+    },
+    {
+      "source": "/docs/luos-technology/basics/basics",
+      "destination": "/docs/luos-technology/basics",
       "statusCode": 301
     },
     {
@@ -125,6 +135,11 @@
     {
       "source": "/docs/next/luos-technology/luos_tech",
       "destination": "/docs/next/luos-technology",
+      "statusCode": 301
+    },
+    {
+      "source": "/docs/next/tools/pyluos",
+      "destination": "/docs/integrations/pyluos",
       "statusCode": 301
     },
     {
@@ -198,6 +213,11 @@
       "statusCode": 301
     },
     {
+      "source": "/pages/demo_boards/demo-boards",
+      "destination": "/docs/compatibility/mcu_demoboard",
+      "statusCode": 301
+    },
+    {
       "source": "/pages/demo_boards/boards_list/led-strip(.*)",
       "destination": "/docs/compatibility/mcu_demoboard",
       "statusCode": 301
@@ -219,7 +239,7 @@
     },
     {
       "source": "/pages/embedded/dev_env/arduino(.*)",
-      "destination": "/tutorials/arduino/intro",
+      "destination": "/tutorials/arduino",
       "statusCode": 301
     },
     {
@@ -402,6 +422,10 @@
       "destination": "https://discord.gg/luos"
     },
     {
+      "source": "/us/contact",
+      "destination": "https://discord.gg/luos"
+    },
+    {
       "source": "/us/pricing",
       "destination": "/",
       "statusCode": 301
@@ -417,8 +441,13 @@
       "statusCode": 301
     },
     {
+      "source": "/tutorials/arduino/intro",
+      "destination": "/tutorials/arduino",
+      "statusCode": 301
+    },
+    {
       "source": "/tutorials/luos-and-tools/arduino",
-      "destination": "/tutorials/arduino/intro",
+      "destination": "/tutorials/arduino",
       "statusCode": 301
     },
     {


### PR DESCRIPTION
⚠ PLEASE DO NOT DELETE THE TEXT BELOW ⚠

## Pull request's description

I've add some redirections based on Google Analytics reports.

## Checklist before merging (please do not edit)
You must review you work before to submit the review to others.

### Self-review of your content
Remember the content must be readable and understandable by someone else than yourself.
- [x] From a technical point of view.
- [x] From a grammatical point of view (spelling mistakes, typos, clarity, etc.), and following the guidelines at the bottom.

### External reviews of your content
- [ ] You requested a technical review.
- [ ] You requested a grammatical review.
- [ ] You validated with @K0rdan or @alexgeron-Luos that it is safe to merge.

### Some guidelines to keep in mind
- Colons (:), semi-colons (;), exclamation (!), and interrogation points (?) are not preceded by a space (like full stops and commas). E.g.: Colons!
- File names and/or address are put in *italic*. E.g.: The file _main.c_.
- Functions, variables, or more generally short codes are put between grave accents. E.g.: To obtain `code()`, type \`code()\`.
- Long codes are put into blocks of code with three grave accent on each side, and the language's name:<br />
\`\`\`c<br />
// Some C language <br />
\`\`\`<br />

- "Luos engine" has a upper case on the **L** for "Luos" and lower case on the **e** for "engine".
- We call it "Luos engine" as a proper name, and ***not*** "the Luos engine".
- Following that fashion, anything that's owned by "Luos engine" implies that we must use `'s` as the standard English rule to show the possessive case, e.g. "Luos engine's API".
- The names pipe, gate, inspector, sniffer, app or application, driver, etc. have a lower case and can be refereed with the determiner `the`. E.g.: The inspector.
