### PR TITLE
Updated the getting started docs for linux based OS.

### DIFF
--- a/tutorials/get-started/get-started.mdx
+++ b/tutorials/get-started/get-started.mdx
@@ -166,8 +166,12 @@ Congratulations, your first Luos app is running!
 <TabItem value="No board" label="No board">
 
 When you build your application, an executable program is generated. Run the application that you just built by going in the folder *Get_started\No-Board\.pio\build\native* and launch *program.exe*.
-If you are using a Linux-based OS then type *./.pio/build/native/program*.  
-In a terminal, you should see the program runing an the "LED" blinking.
+
+:::tip
+If you are using a Linux-based OS instead of Windows, then open a terminal and type `./.pio/build/native/program`.  
+:::
+
+In the terminal, you should see the program running and the "LED" blinking.
 
 <Image
   src="/assets/images/tutorials/get-started/no_board_1.png"
@@ -175,7 +179,7 @@ In a terminal, you should see the program runing an the "LED" blinking.
 />
 
 Congratulations, your first Luos app is running!
-To exit from the terminal press ctrl+C.
+
   </TabItem>
 </Tabs>
 

--- a/tutorials/get-started/get-started.mdx
+++ b/tutorials/get-started/get-started.mdx
@@ -166,6 +166,7 @@ Congratulations, your first Luos app is running!
 <TabItem value="No board" label="No board">
 
 When you build your application, an executable program is generated. Run the application that you just built by going in the folder *Get_started\No-Board\.pio\build\native* and launch *program.exe*.
+If you are using a Linux-based OS then type *./.pio/build/native/program*.  
 In a terminal, you should see the program runing an the "LED" blinking.
 
 <Image
@@ -174,7 +175,7 @@ In a terminal, you should see the program runing an the "LED" blinking.
 />
 
 Congratulations, your first Luos app is running!
-
+To exit from the terminal press ctrl+C.
   </TabItem>
 </Tabs>
 


### PR DESCRIPTION
⚠ PLEASE DO NOT DELETE THE TEXT BELOW ⚠

## Pull request's description
*This PR is linked to #536 *
*Added the instructions to run the built file on Linux based OS. Getting-Started Docs only mentioned the instructions for windows based OS previously.*

## Checklist before merging (please do not edit)
You must review you work before to submit the review to others.

### Self-review of your content
Remember the content must be readable and understandable by someone else than yourself.
- [ ✅ ] From a technical point of view.
- [ ✅ ] From a grammatical point of view (spelling mistakes, typos, clarity, etc.), and following the guidelines at the bottom.

### External reviews of your content
- [ ❌ ] You requested a technical review.
- [ ❌ ] You requested a grammatical review.
- [ ❌ ] You validated with @K0rdan or @alexgeron-Luos that it is safe to merge.

### Some guidelines to keep in mind
- Colons (:), semi-colons (;), exclamation (!), and interrogation points (?) are not preceded by a space (like full stops and commas). E.g.: Colons!
- File names and/or address are put in *italic*. E.g.: The file _main.c_.
- Functions, variables, or more generally short codes are put between grave accents. E.g.: To obtain `code()`, type \`code()\`.
- Long codes are put into blocks of code with three grave accent on each side, and the language's name:<br />
\`\`\`c<br />
// Some C language <br />
\`\`\`<br />

- "Luos engine" has a upper case on the **L** for "Luos" and lower case on the **e** for "engine".
- We call it "Luos engine" as a proper name, and ***not*** "the Luos engine".
- Following that fashion, anything that's owned by "Luos engine" implies that we must use `'s` as the standard English rule to show the possessive case, e.g. "Luos engine's API".
- The names pipe, gate, inspector, sniffer, app or application, driver, etc. have a lower case and can be refereed with the determiner `the`. E.g.: The inspector.
