### PR TITLE
Update Image component to better handle positioning in Safari

### DIFF
--- a/blog/2023-01-16-simplify-debugging-to-remove-complexity-from-embedded-system-development.mdx
+++ b/blog/2023-01-16-simplify-debugging-to-remove-complexity-from-embedded-system-development.mdx
@@ -15,7 +15,7 @@ date: 2023-01-16T12:00
 
 import Image from '@site/src/components/Image';
 
-*This article was originally for <a href="https://techcrunch.com/2022/12/20/simplify-debugging-to-reduce-the-complexity-of-embedded-system-development/Techcrunch" rel="external nofollow">Techcrunch</a> (available with a Techcrunch+ subscription).*
+*This article was originally for <a href="https://techcrunch.com/2022/12/20/simplify-debugging-to-reduce-the-complexity-of-embedded-system-development/" rel="external nofollow">Techcrunch</a> (available with a Techcrunch+ subscription).*
 
 The complexity associated with the development of embedded systems is increasing rapidly. For instance, it is estimated that the average complexity of software projects in the automotive industry has grown <a href="https://www.mckinsey.com/industries/advanced-electronics/our-insights/cracking-the-complexity-code-in-embedded-systems-development" rel="external nofollow">300% over the past decade</a>.
 

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -14,7 +14,7 @@ const Image = (props) => {
   const height = props.height === undefined ? '100%' : props.height;
   const width = props.width === undefined ? null : props.width;
   return (
-    <div style={{ display: 'inline', marginRight: '15px' }}>
+    <div style={{ display: 'inline-flex', marginRight: '15px' }}>
       <img
         className="imgPreview"
         src={source}


### PR DESCRIPTION
⚠ PLEASE DO NOT DELETE THE TEXT BELOW ⚠

## Pull request's description

*Add here a description of the modifications you made.*

## Checklist before merging (please do not edit)
You must review you work before to submit the review to others.

### Self-review of your content
Remember the content must be readable and understandable by someone else than yourself.
- [ ] From a technical point of view.
- [ ] From a grammatical point of view (spelling mistakes, typos, clarity, etc.), and following the guidelines at the bottom.

### External reviews of your content
- [ ] You requested a technical review.
- [ ] You requested a grammatical review.
- [ ] You validated with @K0rdan or @alexgeron-Luos that it is safe to merge.

### Some guidelines to keep in mind
- Colons (:), semi-colons (;), exclamation (!), and interrogation points (?) are not preceded by a space (like full stops and commas). E.g.: Colons!
- File names and/or address are put in *italic*. E.g.: The file _main.c_.
- Functions, variables, or more generally short codes are put between grave accents. E.g.: To obtain `code()`, type \`code()\`.
- Long codes are put into blocks of code with three grave accent on each side, and the language's name:<br />
\`\`\`c<br />
// Some C language <br />
\`\`\`<br />

- "Luos engine" has a upper case on the **L** for "Luos" and lower case on the **e** for "engine".
- We call it "Luos engine" as a proper name, and ***not*** "the Luos engine".
- Following that fashion, anything that's owned by "Luos engine" implies that we must use `'s` as the standard English rule to show the possessive case, e.g. "Luos engine's API".
- The names pipe, gate, inspector, sniffer, app or application, driver, etc. have a lower case and can be refereed with the determiner `the`. E.g.: The inspector.
